### PR TITLE
feat: add codex in devcontainer

### DIFF
--- a/template/.devcontainer/devcontainer.json
+++ b/template/.devcontainer/devcontainer.json
@@ -49,12 +49,13 @@
 	},
 	"remoteUser": "vscode",
 	"containerUser": "vscode",
+	"initializeCommand": "mkdir -p ${localEnv:HOME}/.claude ${localEnv:HOME}/.codex && touch ${localEnv:HOME}/.claude/CLAUDE.md ${localEnv:HOME}/.codex/config.toml",
 	"mounts": [
 		"source=shell_history-${devcontainerId},target=/shell_history,type=volume",
-		"source=${localEnv:HOME}/.claude,target=/home/vscode/.claude,type=bind,consistency=cached",
-		"source=${localEnv:HOME}/.claude/CLAUDE.md,target=/home/vscode/.claude/CLAUDE.md,type=bind,consistency=cached",
-		"source=${localEnv:HOME}/.codex,target=/home/vscode/.codex,type=bind,consistency=cached",
-		"source=${localEnv:HOME}/.codex/config.toml,target=/home/vscode/.codex/config.toml,type=bind,consistency=cached"
+		"source=${localEnv:HOME}/.claude,target=/home/vscode/.claude,type=bind",
+		"source=${localEnv:HOME}/.claude/CLAUDE.md,target=/home/vscode/.claude/CLAUDE.md,type=bind",
+		"source=${localEnv:HOME}/.codex,target=/home/vscode/.codex,type=bind",
+		"source=${localEnv:HOME}/.codex/config.toml,target=/home/vscode/.codex/config.toml,type=bind"
 	],
 	"postCreateCommand": "npm install -g @openai/codex@latest && uv sync",
 	"postStartCommand": "uv run pre-commit install"

--- a/template/.devcontainer/devcontainer.json
+++ b/template/.devcontainer/devcontainer.json
@@ -5,10 +5,11 @@
 		"DISPLAY": "${localEnv:DISPLAY}",
 		"PYTHONUNBUFFERED": "1",
 		"PYTHONDONTWRITEBYTECODE": "1",
-		"UV_CACHE_DIR": "${containerWorkspaceFolder}/.cache/uv",
+		"UV_CACHE_DIR": "/home/vscode/.cache/uv",
 		"UV_LINK_MODE": "copy",
 		"UV_PROJECT_ENVIRONMENT": "/home/vscode/.venv",
-		"UV_COMPILE_BYTECODE": "1"
+		"UV_COMPILE_BYTECODE": "1",
+		"CLAUDE_CONFIG_DIR": "/home/vscode/.claude"
 	},
 	"features": {
 		"ghcr.io/devcontainers/features/github-cli:1": {},
@@ -16,7 +17,7 @@
 			"configureZshAsDefaultShell": true
 		},
 		"ghcr.io/rocker-org/devcontainer-features/apt-packages:1": {
-			"packages": "curl,wget,git,jq,ca-certificates,build-essential,ripgrep"
+			"packages": "curl,wget,git,jq,ca-certificates,build-essential,ripgrep,fd-find"
 		},
 		"ghcr.io/va-h/devcontainers-features/uv:1": {
 			"shellAutocompletion": true
@@ -46,9 +47,15 @@
 			]
 		}
 	},
+	"remoteUser": "vscode",
+	"containerUser": "vscode",
 	"mounts": [
-		"source=claude-code-config,target=/home/vscode/.claude,type=volume"
+		"source=shell_history-${devcontainerId},target=/shell_history,type=volume",
+		"source=${localEnv:HOME}/.claude,target=/home/vscode/.claude,type=bind,consistency=cached",
+		"source=${localEnv:HOME}/.claude/CLAUDE.md,target=/home/vscode/.claude/CLAUDE.md,type=bind,consistency=cached",
+		"source=${localEnv:HOME}/.codex,target=/home/vscode/.codex,type=bind,consistency=cached",
+		"source=${localEnv:HOME}/.codex/config.toml,target=/home/vscode/.codex/config.toml,type=bind,consistency=cached"
 	],
-	"postCreateCommand": "uv sync",
+	"postCreateCommand": "npm install -g @openai/codex@latest && uv sync",
 	"postStartCommand": "uv run pre-commit install"
 }


### PR DESCRIPTION
This pull request updates the development container configuration to improve environment setup and user experience. The main changes include refining environment variable settings, expanding installed packages, adjusting mount points for configuration sharing, and specifying user settings for the container.

**Environment configuration improvements:**

* Changed the `UV_CACHE_DIR` environment variable to use a fixed path (`/home/vscode/.cache/uv`) and added a new `CLAUDE_CONFIG_DIR` variable for Claude configuration (`/home/vscode/.claude`).

**Package and feature enhancements:**

* Added `fd-find` to the list of installed packages for enhanced file searching capabilities.

**User and mount point adjustments:**

* Set both `remoteUser` and `containerUser` to `vscode` to ensure consistent user context within the container.
* Updated mount points to bind local `.claude` and `.codex` configuration directories and files into the container, and added a shell history volume for improved developer workflow.

**Post-creation and startup commands:**

* Enhanced the `postCreateCommand` to install the latest version of `@openai/codex` globally via npm before syncing Python dependencies.