### PR TITLE
feat: support Python 3.14 in generated projects

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
       - uses: actions/checkout@v4
       - name: Install uv

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A simple modern Python project template powered by [Copier](https://copier.readt
 
 ## Features
 
-- 🚀 **Modern Python**: Support for Python 3.10-3.13
+- 🚀 **Modern Python**: Support for Python 3.10-3.14
 - 📦 **uv Package Manager**: Fast and reliable package management with [uv](https://github.com/astral-sh/uv)
 - 🐳 **Docker Support**: Complete Docker development environment
 - 📦 **Devcontainer Support**: VS Code devcontainer for consistent development
@@ -36,7 +36,7 @@ uvx copier copy gh:mjun0812/python-copier-template your-project-name
 Follow the interactive prompts to configure your project:
 
 - **Project name**: Your project's name
-- **Python version**: Choose from 3.10, 3.11, 3.12, or 3.13
+- **Python version**: Choose from 3.10, 3.11, 3.12, 3.13, or 3.14
 - **Package name**: The name used for importing your package (e.g., `import package_name`)
 - **Description**: A short description of your project
 - **Author name**: Your name

--- a/copier.yml
+++ b/copier.yml
@@ -12,13 +12,14 @@ project_name:
 
 python_version:
   type: str
-  default: "3.12"
+  default: "3.13"
   help: Which version of Python do you want to use?
   choices:
     - "3.10"
     - "3.11"
     - "3.12"
     - "3.13"
+    - "3.14"
 
 package_name:
   type: str

--- a/template/.devcontainer/devcontainer.json
+++ b/template/.devcontainer/devcontainer.json
@@ -7,6 +7,7 @@
 		"PYTHONDONTWRITEBYTECODE": "1",
 		"UV_CACHE_DIR": "/home/vscode/.cache/uv",
 		"UV_LINK_MODE": "copy",
+		"UV_PYTHON_PREFERENCE": "only-managed",
 		"UV_PROJECT_ENVIRONMENT": "/home/vscode/.venv",
 		"UV_COMPILE_BYTECODE": "1",
 		"CLAUDE_CONFIG_DIR": "/home/vscode/.claude"


### PR DESCRIPTION
## Overview and Background

This PR updates the default Python version for newly generated projects to 3.13 and expands the selectable and CI-tested range to Python 3.10 through 3.14.

Previously, the template defaulted to Python 3.12, did not offer Python 3.14, and did not test Python 3.14 in CI. In addition, when the Dev Container base image provided a matching minimal system Python installation, uv could select an interpreter with an incomplete standard library.

## Related Issues

None.

## Implementation Approach

Keep the Copier choices, generated-project documentation, and template CI matrix aligned to the same supported range. Use Python 3.13 as the default while allowing Python 3.14 to be selected explicitly. Restrict Dev Containers to uv-managed Python installations so they do not depend on the base image's system Python.

## Changes

- Change the default Python version for new projects to 3.13.
- Allow Python 3.10 through 3.14 to be selected.
- Add Python 3.14 to the template CI matrix.
- Set `UV_PYTHON_PREFERENCE=only-managed` in Dev Containers.
- Update the supported range and choices in the README.

## Impact

- Projects generated without an explicit selection now require Python 3.13.
- Existing workflows that explicitly select Python 3.10 through 3.12 remain supported.
- Dev Containers download a uv-managed Python installation during initial setup.
- Already generated projects are unaffected.

## Validation Results

- `oxfmt README.md`: passed.
- `git diff --check`: passed.
- Generated a project with Copier 9.17.2 using defaults and verified `.python-version=3.13`, `requires-python >=3.13`, and Ruff `target-version=py313`.
- Generated a project with Copier 9.17.2 using Python 3.14 and verified `.python-version=3.14`, `requires-python >=3.14`, and Ruff `target-version=py314`.
- `uv sync && uv run pytest -q` with Python 3.13.12: 2 tests passed.
- `uv sync && uv run pytest -q` with Python 3.14.6: 2 tests passed.
- `npx --yes @devcontainers/cli build --workspace-folder .` on a Python 3.14 generated project: passed.
- `npx --yes @devcontainers/cli up --workspace-folder .` on a Python 3.14 generated project: used uv-managed CPython 3.14.7 and completed the project build, dependency sync, and pre-commit installation.
- Rebased onto the latest `main`, including the Ruff preview-rule fix.
- GitHub Actions passed for Python 3.10 through 3.14, including the aggregate status check.
