### PR TITLE
fix: disable Ruff preview rules by default

### DIFF
--- a/template/pyproject.toml
+++ b/template/pyproject.toml
@@ -23,7 +23,6 @@ target-version = "py{{python_version | replace('.', '')}}"
 exclude = [".git", ".ruff_cache", ".venv", ".vscode"]
 
 [tool.ruff.lint]
-preview = true
 select = [
     "ANN", # type annotation
     "B",   # flake8-bugbear


### PR DESCRIPTION
## Overview and Background

This PR prevents generated projects from enabling Ruff preview rules by default. Previously, upgrading Ruff could automatically introduce new preview rules through selected rule categories and break linting and CI without any template changes.

With Ruff 0.16.5, `RUF201` reported 28 rule-code selectors in the configuration and `RUF067` reported one implementation in `__init__.py`.

## Related Issues

None.

## Implementation Approach

Remove `preview = true` and rely on Ruff's default of disabling preview rules. Keep the existing stable rule selection unchanged so additional rules can be evaluated and enabled deliberately.

## Changes

- Remove the blanket enablement of preview rules from generated Ruff configurations.
- Prevent new preview rules from entering the quality gate implicitly after Ruff upgrades.

## Impact

- Newly generated projects lint against stable rules only.
- The existing stable rule selection and Ruff formatter behavior remain unchanged.
- Python runtime behavior, dependencies, and public APIs are unaffected.

## Validation Results

- Before the change, Ruff 0.16.5 reported 28 `RUF201` violations and one `RUF067` violation.
- Generated a project with Python 3.12 using Copier.
- `uv sync`: passed.
- `uv run ruff --version`: `ruff 0.16.5`.
- `uv run ruff format --check .`: 6 files already formatted.
- `uv run ruff check --output-format=concise .`: all checks passed.
- `uv run pytest -q`: 2 tests passed.
- GitHub Actions passed for Python 3.10 through 3.13, including the aggregate status check.
