### PR TITLE
feat: enforce public API docstrings and safer defaults

### DIFF
--- a/template/main.py
+++ b/template/main.py
@@ -2,6 +2,7 @@ from {{package_name}} import hello
 
 
 def main() -> None:
+    """Print the greeting for the generated project."""
     print(hello())
 
 

--- a/template/pyproject.toml
+++ b/template/pyproject.toml
@@ -38,12 +38,10 @@ select = [
 ]
 ignore = [
     "ANN401", # Checks that function arguments are annotated with a more specific type than Any.
-    "B007",   # Unused loop variable
-    "B008",   # Function call in default argument
     "B905",   # `zip()` without `strict=True`
     "COM812", # Missing trailing comma
     "COM819", # Trailing comma prohibited
-    "D1",     # Missing docstring in public module, class, function, or method
+    "D100",   # Missing docstring in public module
     "D203",   # One blank line required before class docstring (ignored because D211 is prioritized in pydocstyle convention 'google')
     "D205",   # 1 blank line required between summary line and description
     "D212",   # Multi-line docstring summary should start at the first line

--- a/template/src/{{package_name}}/__init__.py
+++ b/template/src/{{package_name}}/__init__.py
@@ -1,2 +1,6 @@
+"""Public interface for the generated package."""
+
+
 def hello() -> str:
+    """Return a greeting for the generated project."""
     return "Hello from {{project_name}}!"

--- a/template/tests/test_hello.py
+++ b/template/tests/test_hello.py
@@ -2,11 +2,13 @@ from {{package_name}} import hello
 
 
 def test_hello() -> None:
+    """Test that hello returns the project greeting."""
     result = hello()
     expected = "Hello from {{project_name}}!"
     assert result == expected
 
 
 def test_hello_return_type() -> None:
+    """Test that hello returns a string."""
     result = hello()
     assert isinstance(result, str)


### PR DESCRIPTION
## Overview and Background

This PR adds Ruff quality gates for public API docstrings, unused loop variables, and function calls in default arguments in generated projects.

Previously, `D1`, `B007`, and `B008` were ignored, so the template did not detect missing docstrings on public packages, classes, methods, and functions, unclear unused loop variables, or default values evaluated only once at function definition time.

## Related Issues

None.

## Implementation Approach

Keep the existing `D` and `B` category selections and remove only the approved exceptions. Ignore `D100` for public modules while enabling `D101` through `D107`. Keep `B905` ignored so `zip()` does not require an explicit `strict` argument.

## Changes

- Enable `D101` through `D107`.
- Enable `B007` and `B008`.
- Keep the `B905` exception.
- Add docstrings to the generated package, public functions, entry point, and test functions so a new project passes the stricter rules immediately.

## Impact

- Newly added public classes, methods, functions, packages, magic methods, and `__init__` methods require docstrings.
- Intentionally unused loop variables must use an underscore prefix.
- Function calls in default arguments must move into the function body or be explicitly allowed through configuration.
- `zip()` usage, runtime behavior, and dependencies are unaffected.

## Validation Results

- Generated a project with Python 3.12 using Copier.
- `uv sync`: passed.
- `uvx ruff format .`: 6 files left unchanged.
- `uvx ruff check --fix .`: all checks passed.
- `uvx ruff check .`: all checks passed.
- `uvx ty check`: all checks passed.
- `uv run pytest -q`: 2 tests passed.
- `uvx ruff check --show-settings .`: verified that `D101` through `D107`, `B007`, and `B008` are enabled while `B905` remains disabled.
- GitHub Actions passed for Python 3.10 through 3.13, including the aggregate status check.
