### PR TITLE
ci: upgrade GitHub Actions runtime dependencies

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Create Release
         run: |
           gh release create ${{github.ref_name}} --generate-notes

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,10 +16,10 @@ jobs:
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
-      - uses: actions/setup-node@v4
+        uses: astral-sh/setup-uv@v10.0.1
+      - uses: actions/setup-node@v7
         with:
           node-version: latest
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,6 +19,8 @@ jobs:
       - uses: actions/checkout@v7
       - name: Install uv
         uses: astral-sh/setup-uv@v10.0.1
+        with:
+          cache-suffix: ${{ matrix.python-version }}
       - uses: actions/setup-node@v7
         with:
           node-version: latest

--- a/.github/workflows/trigger-template-update.yml
+++ b/.github/workflows/trigger-template-update.yml
@@ -18,14 +18,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout child repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           repository: ${{ github.event.inputs.target_repository || 'mjun0812/python-project-template' }}
           token: ${{ secrets.CHILD_REPO_TOKEN }}
           path: child-repo
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v10.0.1
 
       - name: Update template in child repository
         working-directory: child-repo
@@ -45,7 +45,7 @@ jobs:
 
       - name: Create Pull Request
         if: steps.changes.outputs.has_changes == 'true'
-        uses: peter-evans/create-pull-request@v5
+        uses: peter-evans/create-pull-request@v8
         with:
           token: ${{ secrets.CHILD_REPO_TOKEN }}
           path: child-repo

--- a/template/.github/workflows/ci.yml
+++ b/template/.github/workflows/ci.yml
@@ -12,9 +12,9 @@ jobs:
   ci:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v10.0.1
 
       - name: Sync dependencies
         run: uv sync --locked


### PR DESCRIPTION
## Overview and Background

This PR moves the template repository and generated-project CI to current GitHub Action releases that use the supported runner runtime. The previous action majors emitted Node.js 20 deprecation warnings, and `create-pull-request@v5` was rejected by actionlint as too old for GitHub Actions.

## Related Issues

None.

## Implementation Approach

Use the requested current major releases for actions that publish floating major references. Pin setup-uv to `v10.0.1` because its repository does not publish a floating `v10` reference. Apply the same checkout and setup-uv versions to the generated-project workflow so new repositories start from the same baseline. Add the matrix Python version to setup-uv cache keys so concurrent jobs do not reserve the same cache entry.

## Changes

- Upgrade checkout and setup-node from v4 to v7.
- Upgrade setup-uv from v6 to v10.0.1.
- Upgrade create-pull-request from v5 to v8.
- Separate setup-uv caches by Python matrix version.
- Update the generated-project CI workflow to checkout v7 and setup-uv v10.0.1.

## Impact

GitHub-hosted CI and release automation use action releases compatible with the current runner runtime. Python support, dependency resolution, and generated application behavior are unchanged.

## Validation Results

- Verified that the configured action references exist in their upstream repositories.
- `actionlint .github/workflows/release.yml .github/workflows/test.yml template/.github/workflows/ci.yml`: passed.
- Compared actionlint output for the template update workflow before and after the change. The obsolete create-pull-request diagnostic was removed; two pre-existing shell quoting diagnostics remain unchanged.
- Generated a Python 3.13 project with Copier and passed actionlint on its generated CI workflow.
- The initial GitHub Actions run passed checkout v7, setup-node v7, setup-uv v10.0.1, dependency synchronization, Ruff, pytest, Docker, and Docker Compose across Python 3.10 through 3.14. Its setup-uv cache reservation warning led to the per-version cache suffix added in the follow-up commit.
- `git diff --check origin/main..HEAD`: passed.
