### PR TITLE
ci: add Dependabot version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,11 @@ jobs:
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
       - uses: actions/checkout@v7
+      - name: Check shared action versions
+        run: |
+          diff \
+            <(grep -oE '(actions/checkout|astral-sh/setup-uv)@[^[:space:]]+' .github/workflows/test.yml) \
+            <(grep -oE '(actions/checkout|astral-sh/setup-uv)@[^[:space:]]+' template/.github/workflows/ci.yml)
       - name: Install uv
         uses: astral-sh/setup-uv@v10.0.1
         with:

--- a/template/.github/dependabot.yml
+++ b/template/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
## Overview and Background

This PR adds weekly dependency update automation for both the template repository and repositories generated from it. Previously, action and Python dependency versions could remain stale until they were reviewed manually.

## Related Issues

None.

## Implementation Approach

Keep the repository-level and generated-project responsibilities separate. The root Dependabot configuration monitors the template repository's executable GitHub workflows. A second configuration under `template/` is copied to generated repositories, where it monitors that repository's GitHub Actions and uv manifests. Root CI treats its test workflow as the source of truth for shared action versions and compares those references with the generated workflow.

## Changes

- Check the template repository's GitHub Actions for updates every week.
- Generate weekly GitHub Actions update configuration for new projects.
- Generate weekly uv dependency update configuration for new projects.
- Fail root CI when the shared `actions/checkout` or `astral-sh/setup-uv` versions differ between root and template workflows.

## Impact

Dependabot can open version update pull requests but does not merge them automatically. A root action update must include the matching template workflow version to pass CI. Existing generated repositories receive the Dependabot configuration only when they apply a Copier template update.

## Validation Results

- Parsed both Dependabot files as YAML successfully.
- Generated a Python 3.13 project with Copier and verified `.github/dependabot.yml` was present.
- Verified the generated configuration contains exactly the `github-actions` and `uv` ecosystems.
- Confirmed the generated file matches the template source.
- Confirmed matching shared action versions pass the consistency check.
- Confirmed a simulated `setup-uv` mismatch fails the consistency check.
- `actionlint .github/workflows/test.yml`: passed.
- `git diff --check`: passed.
