### PR TITLE
feat: install the latest standalone Codex in dev containers

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,6 +33,7 @@ jobs:
       - name: Copy Template
         run: |
           uvx copier copy \
+            --vcs-ref HEAD \
             ./ \
             /tmp/test-copier \
             -d project_name=test-copier \

--- a/template/.devcontainer/Dockerfile
+++ b/template/.devcontainer/Dockerfile
@@ -1,24 +1,12 @@
 FROM mcr.microsoft.com/devcontainers/base:ubuntu-24.04
 
-ARG CODEX_VERSION=0.121.0
-ARG CODEX_SHA256_AMD64=f053ac81e9c6769920f9ee3566abad47ab0856eb7ee792428681664ece113430
-ARG CODEX_SHA256_ARM64=9ce5edd5524898ad2e95b59f278977e312726e0587957d1f10ee389070fe5034
-
-SHELL ["/bin/bash", "-o", "pipefail", "-c"]
-
 RUN apt-get update \
     && apt-get install -y --no-install-recommends ca-certificates curl \
-    && case "$(uname -m)" in \
-        x86_64) codex_target="x86_64-unknown-linux-gnu"; codex_sha256="${CODEX_SHA256_AMD64}" ;; \
-        aarch64 | arm64) codex_target="aarch64-unknown-linux-gnu"; codex_sha256="${CODEX_SHA256_ARM64}" ;; \
-        *) echo "Unsupported architecture: $(uname -m)" >&2; exit 1 ;; \
-    esac \
-    && curl -fsSL \
-        "https://github.com/openai/codex/releases/download/rust-v${CODEX_VERSION}/codex-${codex_target}.tar.gz" \
-        -o /tmp/codex.tar.gz \
-    && echo "${codex_sha256}  /tmp/codex.tar.gz" | sha256sum --check --strict \
-    && tar -xzf /tmp/codex.tar.gz -C /tmp \
-    && install -m 0755 "/tmp/codex-${codex_target}" /usr/local/bin/codex \
-    && rm -f /tmp/codex.tar.gz "/tmp/codex-${codex_target}" \
+    && curl -fsSL https://github.com/openai/codex/releases/latest/download/install.sh -o /tmp/install-codex.sh \
+    && CODEX_INSTALL_DIR=/usr/local/bin \
+        CODEX_HOME=/opt/codex \
+        CODEX_NON_INTERACTIVE=1 \
+        sh /tmp/install-codex.sh \
+    && rm -f /tmp/install-codex.sh \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*

--- a/template/.devcontainer/Dockerfile
+++ b/template/.devcontainer/Dockerfile
@@ -1,0 +1,24 @@
+FROM mcr.microsoft.com/devcontainers/base:ubuntu-24.04
+
+ARG CODEX_VERSION=0.121.0
+ARG CODEX_SHA256_AMD64=f053ac81e9c6769920f9ee3566abad47ab0856eb7ee792428681664ece113430
+ARG CODEX_SHA256_ARM64=9ce5edd5524898ad2e95b59f278977e312726e0587957d1f10ee389070fe5034
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates curl \
+    && case "$(uname -m)" in \
+        x86_64) codex_target="x86_64-unknown-linux-gnu"; codex_sha256="${CODEX_SHA256_AMD64}" ;; \
+        aarch64 | arm64) codex_target="aarch64-unknown-linux-gnu"; codex_sha256="${CODEX_SHA256_ARM64}" ;; \
+        *) echo "Unsupported architecture: $(uname -m)" >&2; exit 1 ;; \
+    esac \
+    && curl -fsSL \
+        "https://github.com/openai/codex/releases/download/rust-v${CODEX_VERSION}/codex-${codex_target}.tar.gz" \
+        -o /tmp/codex.tar.gz \
+    && echo "${codex_sha256}  /tmp/codex.tar.gz" | sha256sum --check --strict \
+    && tar -xzf /tmp/codex.tar.gz -C /tmp \
+    && install -m 0755 "/tmp/codex-${codex_target}" /usr/local/bin/codex \
+    && rm -f /tmp/codex.tar.gz "/tmp/codex-${codex_target}" \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*

--- a/template/.devcontainer/Dockerfile
+++ b/template/.devcontainer/Dockerfile
@@ -1,12 +1,24 @@
+# syntax=docker/dockerfile:1
+
 FROM mcr.microsoft.com/devcontainers/base:ubuntu-24.04
 
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends ca-certificates curl \
+RUN rm -f /etc/apt/apt.conf.d/docker-clean \
+    && echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    apt-get update \
+    && apt-get install -y --no-install-recommends \
+        build-essential \
+        ca-certificates \
+        curl \
+        fd-find \
+        git \
+        jq \
+        ripgrep \
+        wget \
     && curl -fsSL https://github.com/openai/codex/releases/latest/download/install.sh -o /tmp/install-codex.sh \
     && CODEX_INSTALL_DIR=/usr/local/bin \
         CODEX_HOME=/opt/codex \
         CODEX_NON_INTERACTIVE=1 \
         sh /tmp/install-codex.sh \
-    && rm -f /tmp/install-codex.sh \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
+    && rm -f /tmp/install-codex.sh

--- a/template/.devcontainer/devcontainer.json
+++ b/template/.devcontainer/devcontainer.json
@@ -52,13 +52,12 @@
 	},
 	"remoteUser": "vscode",
 	"containerUser": "vscode",
-	"initializeCommand": "mkdir -p ${localEnv:HOME}/.claude ${localEnv:HOME}/.codex && touch ${localEnv:HOME}/.claude/CLAUDE.md ${localEnv:HOME}/.codex/config.toml",
+	"initializeCommand": "mkdir -p ${localEnv:HOME}/.claude ${localEnv:HOME}/.codex",
 	"mounts": [
 		"source=shell_history-${devcontainerId},target=/shell_history,type=volume",
+		"source=uv-cache-${devcontainerId},target=/home/vscode/.cache/uv,type=volume",
 		"source=${localEnv:HOME}/.claude,target=/home/vscode/.claude,type=bind",
-		"source=${localEnv:HOME}/.claude/CLAUDE.md,target=/home/vscode/.claude/CLAUDE.md,type=bind",
-		"source=${localEnv:HOME}/.codex,target=/home/vscode/.codex,type=bind",
-		"source=${localEnv:HOME}/.codex/config.toml,target=/home/vscode/.codex/config.toml,type=bind"
+		"source=${localEnv:HOME}/.codex,target=/home/vscode/.codex,type=bind"
 	],
 	"postCreateCommand": "uv sync --locked",
 	"postStartCommand": "uv run pre-commit install"

--- a/template/.devcontainer/devcontainer.json
+++ b/template/.devcontainer/devcontainer.json
@@ -59,6 +59,6 @@
 		"source=${localEnv:HOME}/.claude,target=/home/vscode/.claude,type=bind",
 		"source=${localEnv:HOME}/.codex,target=/home/vscode/.codex,type=bind"
 	],
-	"postCreateCommand": "sudo chown -R vscode:vscode /home/vscode/.cache/uv && uv sync --locked",
+	"postCreateCommand": "sudo chown -R vscode:vscode /home/vscode/.cache && uv sync --locked",
 	"postStartCommand": "uv run pre-commit install"
 }

--- a/template/.devcontainer/devcontainer.json
+++ b/template/.devcontainer/devcontainer.json
@@ -59,6 +59,6 @@
 		"source=${localEnv:HOME}/.claude,target=/home/vscode/.claude,type=bind",
 		"source=${localEnv:HOME}/.codex,target=/home/vscode/.codex,type=bind"
 	],
-	"postCreateCommand": "uv sync --locked",
+	"postCreateCommand": "sudo chown -R vscode:vscode /home/vscode/.cache/uv && uv sync --locked",
 	"postStartCommand": "uv run pre-commit install"
 }

--- a/template/.devcontainer/devcontainer.json
+++ b/template/.devcontainer/devcontainer.json
@@ -1,6 +1,9 @@
 {
 	"name": "python-devcontainer",
-	"image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+	"build": {
+		"dockerfile": "Dockerfile",
+		"context": ".."
+	},
 	"containerEnv": {
 		"DISPLAY": "${localEnv:DISPLAY}",
 		"PYTHONUNBUFFERED": "1",
@@ -18,12 +21,11 @@
 			"configureZshAsDefaultShell": true
 		},
 		"ghcr.io/rocker-org/devcontainer-features/apt-packages:1": {
-			"packages": "curl,wget,git,jq,ca-certificates,build-essential,ripgrep,fd-find"
+			"packages": "wget,git,jq,build-essential,ripgrep,fd-find"
 		},
 		"ghcr.io/va-h/devcontainers-features/uv:1": {
 			"shellAutocompletion": true
 		},
-		"ghcr.io/devcontainers/features/node:1": {},
 		"ghcr.io/anthropics/devcontainer-features/claude-code:1.0": {}
 	},
 	"runArgs": [
@@ -58,6 +60,6 @@
 		"source=${localEnv:HOME}/.codex,target=/home/vscode/.codex,type=bind",
 		"source=${localEnv:HOME}/.codex/config.toml,target=/home/vscode/.codex/config.toml,type=bind"
 	],
-	"postCreateCommand": "npm install -g @openai/codex@latest && uv sync --locked",
+	"postCreateCommand": "uv sync --locked",
 	"postStartCommand": "uv run pre-commit install"
 }

--- a/template/.devcontainer/devcontainer.json
+++ b/template/.devcontainer/devcontainer.json
@@ -20,9 +20,6 @@
 		"ghcr.io/devcontainers/features/common-utils:2": {
 			"configureZshAsDefaultShell": true
 		},
-		"ghcr.io/rocker-org/devcontainer-features/apt-packages:1": {
-			"packages": "wget,git,jq,build-essential,ripgrep,fd-find"
-		},
 		"ghcr.io/va-h/devcontainers-features/uv:1": {
 			"shellAutocompletion": true
 		},

--- a/template/CLAUDE.md
+++ b/template/CLAUDE.md
@@ -1,1 +1,1 @@
-AGENTS.md
+@AGENTS.md


### PR DESCRIPTION
## Overview and Background

This PR modernizes the generated development container by installing the latest stable standalone Codex CLI and by letting Claude Code load the shared agent instructions. Root CI previously rendered the latest template tag instead of the pull request revision, so unreleased template changes were not exercised.

## Related Issues

None.

## Implementation Approach

Build from the official `mcr.microsoft.com/devcontainers/base:ubuntu-24.04` image because Python remains managed by uv for the selected template version. Run the installer published with the latest OpenAI Codex release during image builds, storing the standalone package under `/opt/codex` and exposing `codex` through `/usr/local/bin`. This avoids retaining Node.js solely for Codex and removes the previous Codex version pin.

Install the required Ubuntu packages in the same Dockerfile instead of delegating them to a third-party Feature. Locked BuildKit cache mounts preserve apt metadata and downloaded packages across builds.

Replace the Claude symlink with a regular import file because Claude's instruction import syntax requires `@AGENTS.md` as file content.

Keep tool caches separate from host credentials. The uv cache uses a project-specific named volume, while the host `.claude` and `.codex` directories remain read-write bind mounts so their configuration and file-backed authentication can be reused without redundant nested file mounts.

Copier now receives `--vcs-ref HEAD` in root CI so the generated test project represents the revision under test rather than the latest release tag.

Sources:

- [Dev Containers Ubuntu base image](https://github.com/devcontainers/images/tree/main/src/base-ubuntu)
- [Latest OpenAI Codex release](https://github.com/openai/codex/releases/latest)

## Changes

- Build generated development containers from the Ubuntu 24.04 Dev Containers base image.
- Install the latest stable standalone Codex release through the official installer.
- Install Ubuntu packages through the Dockerfile with locked apt cache mounts.
- Remove the general Node Feature, the apt packages Feature, and the post-create npm installation.
- Persist the uv cache in a named volume.
- Share the host Claude and Codex directories without duplicate nested mounts.
- Generate `CLAUDE.md` as a regular file importing `AGENTS.md`.
- Render the current template revision during root CI.

## Impact

Newly generated projects and projects applying this Copier update resolve the latest stable Codex CLI when the Codex installation layer is built. Codex can therefore change between uncached image builds without a template change. Ubuntu package installation no longer depends on the `rocker-org` Feature. Python selection remains controlled by uv, and the existing Claude Code feature remains unchanged. The generated container has read-write access to the host `.claude` and `.codex` directories, matching the existing credential-sharing behavior.

## Validation Results

- Built the Codex image on arm64 with the official installer, which resolved Codex 0.152.1.
- Ran `codex --version` as the non-root `vscode` user and received `codex-cli 0.152.1`.
- Built the complete Dev Container with all configured Features successfully.
- Verified `wget`, `git`, `jq`, GCC, `rg`, and `fdfind` are available to the non-root user.
- Verified the generated mount list contains one uv cache volume and one bind mount for each host credential directory, with no nested file mounts.
- Verified the generated `CLAUDE.md` contains exactly `@AGENTS.md` and is not a symlink.
- Verified the workflow with `actionlint` and checked the Git diff for whitespace errors.
