### PR TITLE
chore: update pre-commit hook releases

### DIFF
--- a/template/.pre-commit-config.yaml
+++ b/template/.pre-commit-config.yaml
@@ -1,12 +1,12 @@
 repos:
   - repo: https://github.com/astral-sh/uv-pre-commit
     # uv version.
-    rev: 0.8.22
+    rev: 0.12.9
     hooks:
       - id: uv-lock
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.13.2
+    rev: v0.16.5
     hooks:
       # Run the linter.
       - id: ruff-check


### PR DESCRIPTION
## Overview and Background

Update the generated project's pre-commit hooks to the latest stable releases available on 2026-09-03. The previous configuration used uv-pre-commit 0.8.22 and ruff-pre-commit v0.13.2, leaving hook behavior behind current stable releases.

## Related Issues

None.

## Implementation Approach

Update only the existing `rev` values in `template/.pre-commit-config.yaml`, preserving the current hook set and arguments. The versions were selected from the official GitHub release lists using `gh api`, excluding prereleases and drafts.

## Changes

- Set uv-pre-commit to `0.12.9`.
- Set ruff-pre-commit to `v0.16.5`.

## Impact

Generated projects will use newer uv lock and Ruff pre-commit environments. No additional hooks, configuration, runtime behavior, or compatibility layers are introduced.

## Validation Results

- `uvx copier copy . /tmp/python-copier-precommit-generated --defaults -d project_name=test-copier -d package_name=test_copier -d description='Test project' -d author_name=test-copier -d author_email=test-copier@example.com --trust`: passed.
- `uv run pre-commit run --all-files`: passed (`uv-lock`, `ruff check`, and `ruff format`).
- `uv run ruff format --check --diff .`: passed.
- `uv run --frozen pytest -vs`: passed (2 tests).
- `uv run ruff check --output-format=github .`: reports existing `rule-codes-in-selectors` configuration diagnostics in the generated `pyproject.toml`; that file is outside this change.
