### PR TITLE
docs: document devcontainer tools and mounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,12 @@ docker compose up
 ### VS Code Devcontainer
 
 Open the project in VS Code and use the "Reopen in Container" command for a fully configured development environment.
-Devcontainer will automatically install uv, Claude Code, and pre-commit hooks.
+Devcontainer will automatically install uv, Claude Code, and pre-commit hooks. The image build installs the latest
+Codex release, so rebuilding the image updates Codex.
+
+The container mounts the host `${HOME}/.claude` and `${HOME}/.codex` directories at `/home/vscode/.claude` and
+`/home/vscode/.codex` for authentication. These bind mounts are read-write, so changes made in the container can
+affect the host configuration. The uv cache is kept in a named volume and reused across container rebuilds.
 
 ### Update Template
 

--- a/template/README.md
+++ b/template/README.md
@@ -42,3 +42,9 @@ docker compose up
 ### VS Code Devcontainer
 
 Open the project in VS Code and use the "Reopen in Container" command for a fully configured development environment.
+Devcontainer automatically installs uv and Claude Code, and installs the latest Codex release when the image is built.
+Rebuild the image to update Codex.
+
+The container mounts the host `${HOME}/.claude` and `${HOME}/.codex` directories at `/home/vscode/.claude` and
+`/home/vscode/.codex` for authentication. These bind mounts are read-write, so changes made in the container can
+affect the host configuration. The uv cache is kept in a named volume and reused across container rebuilds.


### PR DESCRIPTION
## Overview and Background

Document the devcontainer tools, authentication mounts, and cache behavior in both the repository README and the generated-project README. Previously, the Devcontainer sections did not explain Codex availability, host authentication directories, or the persistence and write behavior of those mounts.

## Related Issues

None.

## Implementation Approach

Align the existing Devcontainer documentation with `template/.devcontainer/devcontainer.json` and `template/.devcontainer/Dockerfile`, keeping the changes limited to the two relevant README sections.

## Changes

- Document automatic installation of uv and Claude Code.
- Document that the image build installs the latest Codex release and that rebuilding updates Codex.
- Document the host `${HOME}/.claude` and `${HOME}/.codex` authentication bind mounts, including their read-write impact on host configuration.
- Document the named uv cache volume and its reuse across container rebuilds.

## Impact

This is a documentation-only change. It clarifies existing setup and the host-side effects of read-write bind mounts; runtime behavior is unchanged.

## Validation Results

- `oxfmt --check README.md template/README.md` — passed.
- `jq empty template/.devcontainer/devcontainer.json` — passed.
- `git diff --check` — passed.
