### PR TITLE
test: verify Copier template lifecycle

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,8 +20,8 @@ jobs:
       - name: Check shared action versions
         run: |
           diff \
-            <(grep -oE '(actions/checkout|astral-sh/setup-uv)@[^[:space:]]+' .github/workflows/test.yml) \
-            <(grep -oE '(actions/checkout|astral-sh/setup-uv)@[^[:space:]]+' template/.github/workflows/ci.yml)
+            <(grep -oE '(actions/checkout|astral-sh/setup-uv)@[^[:space:]]+' .github/workflows/test.yml | sort -u) \
+            <(grep -oE '(actions/checkout|astral-sh/setup-uv)@[^[:space:]]+' template/.github/workflows/ci.yml | sort -u)
       - name: Install uv
         uses: astral-sh/setup-uv@v10.0.1
         with:
@@ -84,10 +84,55 @@ jobs:
           devcontainer build --workspace-folder /tmp/test-copier
           devcontainer up --workspace-folder /tmp/test-copier
 
+  template-lifecycle:
+    name: Template lifecycle
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - name: Install uv
+        uses: astral-sh/setup-uv@v10.0.1
+      - name: Copy historical template
+        run: |
+          uvx copier copy \
+            --vcs-ref v1.0.0 \
+            ./ \
+            /tmp/test-copier-lifecycle \
+            --defaults \
+            -d project_name=lifecycle-project \
+            -d python_version=3.13 \
+            -d package_name=lifecycle_package \
+            -d description="Lifecycle test" \
+            -d author_name="Lifecycle Tester" \
+            -d author_email=lifecycle@example.com
+          git -C /tmp/test-copier-lifecycle init
+          git -C /tmp/test-copier-lifecycle config user.name "Lifecycle Tester"
+          git -C /tmp/test-copier-lifecycle config user.email lifecycle@example.com
+          git -C /tmp/test-copier-lifecycle add .
+          git -C /tmp/test-copier-lifecycle commit -m "chore: initialize generated project"
+      - name: Update to current template
+        run: |
+          uvx copier update --vcs-ref HEAD --defaults /tmp/test-copier-lifecycle
+          if git -C /tmp/test-copier-lifecycle diff --quiet; then
+            echo "Copier update produced no changes"
+            exit 1
+          fi
+          if grep -qx "_commit: v1.0.0" /tmp/test-copier-lifecycle/.copier-answers.yml; then
+            echo "Copier did not update the template revision"
+            exit 1
+          fi
+      - name: Build updated package
+        working-directory: /tmp/test-copier-lifecycle
+        run: |
+          uv build
+          test -f dist/lifecycle_project-0.0.1.tar.gz
+          test -f dist/lifecycle_project-0.0.1-py3-none-any.whl
+
   ci-check:
     name: CI Status Check
     runs-on: ubuntu-latest
-    needs: [ci]
+    needs: [ci, template-lifecycle]
     if: always()
     steps:
       - name: Some checks failed


### PR DESCRIPTION
## Overview and Background

Add a dedicated CI job that validates the generated project's full Copier lifecycle. The existing matrix verifies a fresh copy and its development checks, but it did not prove that a project produced by an older template revision can update to the current revision or that the resulting package builds.

## Related Issues

None.

## Implementation Approach

Generate the fixture from the immutable `v1.0.0` tag, commit it as a Git repository as required by Copier updates, then update it using the current `HEAD`. The job asserts both a generated diff and a changed recorded template revision before building the package. This uses the actual historical-to-current Copier path instead of duplicating the fresh-copy matrix.

## Changes

- Add an isolated `Template lifecycle` CI job with complete Git history so the historical tag is available.
- Update the historical generated project with Copier and fail if the update makes no changes or leaves the old revision recorded.
- Build the updated package and verify both sdist and wheel artifacts.
- Deduplicate shared Action-version matches before comparing them with the generated-project workflow.

## Impact

CI gains one lifecycle job. Generated project contents, template behavior, compatibility, security, and deployment behavior are unchanged.

## Validation Results

```sh
actionlint .github/workflows/test.yml
```

Passed.

```sh
uvx copier copy --vcs-ref v1.0.0 ./ /private/tmp/project --defaults \
  -d project_name=lifecycle-project -d python_version=3.13 \
  -d package_name=lifecycle_package -d description="Lifecycle test" \
  -d author_name="Lifecycle Tester" -d author_email=lifecycle@example.com
git -C /private/tmp/project init
git -C /private/tmp/project add .
git -C /private/tmp/project commit -m "chore: initialize generated project"
uvx copier update --vcs-ref HEAD --defaults /private/tmp/project
uv build --directory /private/tmp/project
```

Passed: Copier updated the project from `v1.0.0` to the current revision, produced a non-empty project diff, and built `lifecycle_project-0.0.1.tar.gz` plus `lifecycle_project-0.0.1-py3-none-any.whl`.
