### PR TITLE
refactor: harden Docker helper scripts

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,6 +26,12 @@ jobs:
         uses: astral-sh/setup-uv@v10.0.1
         with:
           cache-suffix: ${{ matrix.python-version }}
+      - name: Install shell tools
+        run: sudo apt-get update && sudo apt-get install --yes shellcheck shfmt
+      - name: Check template shell scripts
+        run: |
+          shellcheck template/docker/*.sh
+          test -z "$(shfmt --list template/docker/*.sh)"
       - uses: actions/setup-node@v7
         with:
           node-version: latest

--- a/template/.github/workflows/ci.yml
+++ b/template/.github/workflows/ci.yml
@@ -15,9 +15,16 @@ jobs:
       - uses: actions/checkout@v7
       - name: Install uv
         uses: astral-sh/setup-uv@v10.0.1
+      - name: Install shell tools
+        run: sudo apt-get update && sudo apt-get install --yes shellcheck shfmt
 
       - name: Sync dependencies
         run: uv sync --locked
+
+      - name: Check shell scripts
+        run: |
+          shellcheck docker/*.sh
+          test -z "$(shfmt --list docker/*.sh)"
 
       - name: Format
         run: uv run --frozen ruff format . --check --diff

--- a/template/docker/build.sh
+++ b/template/docker/build.sh
@@ -1,14 +1,15 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-cd $(dirname $0)
-cd ../
+set -euo pipefail
+
+cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.."
 
 BUILDER_IMAGE="ubuntu:24.04"
 RUNNER_IMAGE="ubuntu:24.04"
-IMAGE_NAME=$(basename $(pwd) | tr '[:upper:]' '[:lower:]')
+IMAGE_NAME="$(basename -- "$PWD" | tr '[:upper:]' '[:lower:]')"
 
-docker build \
-    --build-arg BUILDER_IMAGE=${BUILDER_IMAGE} \
-    --build-arg RUNNER_IMAGE=${RUNNER_IMAGE} \
-    -t "${IMAGE_NAME}:latest" \
-    -f docker/Dockerfile .
+exec docker build \
+	--build-arg "BUILDER_IMAGE=${BUILDER_IMAGE}" \
+	--build-arg "RUNNER_IMAGE=${RUNNER_IMAGE}" \
+	-t "${IMAGE_NAME}:latest" \
+	-f docker/Dockerfile .

--- a/template/docker/entrypoint.sh
+++ b/template/docker/entrypoint.sh
@@ -1,16 +1,18 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-USER_ID=${USER_ID:-1000}
-GROUP_ID=${GROUP_ID:-1000}
-USER_NAME=${USER_NAME:-user}
-GROUP_NAME=${GROUP_NAME:-group}
+set -euo pipefail
 
-userdel -r ubuntu > /dev/null 2>&1 # For Ubuntu 24.04 image
-groupadd -g ${GROUP_ID} ${GROUP_NAME} > /dev/null 2>&1
-useradd -u ${USER_ID} -g ${GROUP_NAME} -G sudo -o -m ${USER_NAME} > /dev/null 2>&1
+USER_ID="${USER_ID:-1000}"
+GROUP_ID="${GROUP_ID:-1000}"
+USER_NAME="${USER_NAME:-user}"
+GROUP_NAME="${GROUP_NAME:-group}"
+
+userdel -r ubuntu >/dev/null 2>&1 || true # For Ubuntu 24.04 image
+groupadd -g "${GROUP_ID}" "${GROUP_NAME}" >/dev/null 2>&1 || true
+useradd -u "${USER_ID}" -g "${GROUP_NAME}" -G sudo -o -m "${USER_NAME}" >/dev/null 2>&1 || true
 
 if [[ $# -eq 0 ]]; then
-    exec /usr/sbin/gosu ${USER_NAME} bash
+	exec /usr/sbin/gosu "${USER_NAME}" bash
 else
-    /usr/sbin/gosu ${USER_NAME} "$@"
+	exec /usr/sbin/gosu "${USER_NAME}" "$@"
 fi

--- a/template/docker/run.sh
+++ b/template/docker/run.sh
@@ -1,41 +1,59 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-cd $(dirname $0)
-cd ../
+set -euo pipefail
 
-IMAGE_NAME=$(basename $(pwd) | tr '[:upper:]' '[:lower:]')
-USER_ID=`id -u`
-GROUP_ID=`id -g`
-GROUP_NAME=`id -gn`
-USER_NAME=$USER
+cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.."
 
-GPU_OPTION=""
-if docker system info | grep -qE '^\s*Runtimes: .*nvidia.*'; then
-    # Use GPU
-    GPU_OPTION="--gpus all"
+IMAGE_NAME="$(basename -- "$PWD" | tr '[:upper:]' '[:lower:]')"
+USER_ID="$(id -u)"
+GROUP_ID="$(id -g)"
+GROUP_NAME="$(id -gn)"
+USER_NAME="${USER:-}"
+
+DOCKER_OPTIONS=()
+if docker system info | grep -E '^[[:space:]]*Runtimes: .*nvidia.*' >/dev/null; then
+	# Use GPU
+	DOCKER_OPTIONS+=(--gpus all)
 fi
 
 # Check if TTY is available (not in CI environment)
-TTY_OPTION=""
 if [ -t 0 ] && [ -t 1 ]; then
-    TTY_OPTION="-it"
+	DOCKER_OPTIONS+=(-it)
 fi
 
-docker run \
-    $TTY_OPTION \
-    $GPU_OPTION \
-    --rm \
-    --shm-size=32g \
-    --net host \
-    --env DISPLAY=$DISPLAY \
-    --env USER_NAME=$USER_NAME \
-    --env USER_ID=$USER_ID \
-    --env GROUP_NAME=$GROUP_NAME \
-    --env GROUP_ID=$GROUP_ID \
-    --workdir /app \
-    -v $HOME/.Xauthority:/home/$USER_NAME/.Xauthority:rw \
-    -v /tmp/.X11-unix:/tmp/.X11-unix:rw \
-    -v ${PWD}:/app \
-    --name "${IMAGE_NAME}-$(date '+%s')" \
-    "${IMAGE_NAME}:latest" \
-    ${@:-bash}
+DOCKER_OPTIONS+=(
+	--rm
+	--shm-size=32g
+	--net
+	host
+	--env
+	"DISPLAY=${DISPLAY:-}"
+	--env
+	"USER_NAME=${USER_NAME}"
+	--env
+	"USER_ID=${USER_ID}"
+	--env
+	"GROUP_NAME=${GROUP_NAME}"
+	--env
+	"GROUP_ID=${GROUP_ID}"
+	--workdir
+	/app
+	-v
+	"${HOME:-}/.Xauthority:/home/${USER_NAME}/.Xauthority:rw"
+	-v
+	/tmp/.X11-unix:/tmp/.X11-unix:rw
+	-v
+	"${PWD}:/app"
+	--name
+	"${IMAGE_NAME}-$(date '+%s')"
+)
+
+COMMAND=("$@")
+if (($# == 0)); then
+	COMMAND=(bash)
+fi
+
+exec docker run \
+	"${DOCKER_OPTIONS[@]}" \
+	"${IMAGE_NAME}:latest" \
+	"${COMMAND[@]}"


### PR DESCRIPTION
## Overview and Background

This PR hardens the template's Docker helper scripts while preserving their build and run behavior. The previous scripts relied on unquoted expansions, legacy command substitution, and string-based optional arguments, which could split paths or user commands unexpectedly.

## Related Issues

None.

## Implementation Approach

The scripts now use Bash strict mode, quoted path and variable expansions, modern `$(...)` command substitution, and arrays for optional Docker flags and forwarded commands. Each terminal Docker or gosu invocation uses `exec`, so the helper process is replaced directly. Both the repository CI and generated-project CI install and run shfmt and ShellCheck against their respective Docker scripts.

## Changes

- Harden `build.sh`, `run.sh`, and `entrypoint.sh` with safe quoting and strict execution.
- Preserve optional GPU and TTY flags in an argument array, and preserve arbitrary command arguments without word splitting or glob expansion.
- Add shfmt and ShellCheck checks to `.github/workflows/test.yml` and `template/.github/workflows/ci.yml`.

## Impact

Docker image build and run interfaces remain unchanged. Paths and command arguments containing spaces or glob characters are now forwarded as single arguments. CI gains a shell-tool installation step and static checks for Docker scripts; no application runtime or dependency changes are introduced.

## Validation Results

- `shellcheck template/docker/*.sh`: passed.
- `shfmt --list template/docker/*.sh`: passed with no unformatted files.
- `bash -n template/docker/*.sh`: passed.
- Generated a project with `uvx copier copy --vcs-ref HEAD ./ /tmp/test-copier-docker ...`: passed.
- `shellcheck /tmp/test-copier-docker/docker/*.sh`, `shfmt --list /tmp/test-copier-docker/docker/*.sh`, and `bash -n /tmp/test-copier-docker/docker/*.sh`: passed.
- Ran the generated `run.sh` with a fake Docker CLI and arguments containing spaces and glob characters; all arguments were preserved.
- `./docker/build.sh`: could not complete because the local Docker daemon denied BuildKit activity-file access (`operation not permitted`).
