### PR TITLE
chore: default the Python version prompt to 3.14

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -12,7 +12,7 @@ project_name:
 
 python_version:
   type: str
-  default: "3.13"
+  default: "3.14"
   help: Which version of Python do you want to use?
   choices:
     - "3.10"


### PR DESCRIPTION
## Overview and Background

New projects generated with `--defaults` (or by pressing Enter at the Python version prompt) now target Python 3.14. Previously the prompt defaulted to 3.13, even though 3.14 has been the current stable release since October 2025 and is already an accepted choice in `copier.yml` and the CI matrix. Users who accepted the default therefore started on a Python release that is one generation behind.

## Related Issues

None

## Implementation Approach

Only the `default` of the `python_version` prompt is changed. The choice list, the CI matrix, and the historical lifecycle test (which pins 3.13 explicitly) are left untouched, so existing generated projects and template updates are not affected.

## Changes

- `copier.yml`: `python_version` default changed from `"3.13"` to `"3.14"`.

## Impact

- User-facing: only affects new projects that accept the default Python version. Users who pick a version explicitly see no change.
- Compatibility: `copier update` on existing projects keeps their recorded `python_version` answer, so nothing changes for them.
- CI, Docker, and devcontainer configuration are unaffected.

## Validation Results

Generated a project with `--defaults` from this branch and confirmed the default propagates to every consumer of `python_version`:

```bash
uvx copier copy --vcs-ref HEAD --defaults \
  -d project_name=demo -d package_name=demo -d description=demo \
  -d author_name=t -d author_email=t@example.com . /tmp/gen-default
cat /tmp/gen-default/.python-version              # 3.14
grep -E 'requires-python|target-version' /tmp/gen-default/pyproject.toml
# requires-python = ">=3.14"
# target-version = "py314"
grep python_version /tmp/gen-default/.copier-answers.yml   # python_version: '3.14'
```
