### PR TITLE
feat: keep uv.lock across template updates and print next steps

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -1,5 +1,27 @@
 _templates_suffix: ""
 _subdirectory: template
+_skip_if_exists:
+  - uv.lock
+_message_after_copy: |
+  Your project "{{ project_name }}" has been created successfully!
+
+  Next steps:
+
+  1. Change directory to the project root:
+
+     $ cd {{ _copier_conf.dst_path }}
+
+  2. Install dependencies and pre-commit hooks:
+
+     $ uv sync --locked
+     $ uv run pre-commit install
+
+  3. Run the checks:
+
+     $ uv run --frozen ruff format . --check
+     $ uv run --frozen ruff check .
+     $ uv run --frozen ty check
+     $ uv run --frozen pytest
 
 project_name:
   type: str


### PR DESCRIPTION
## Overview and Background

`copier update` now leaves a generated project's `uv.lock` alone, and `copier copy` ends with a short list of the commands to run next. Previously the template shipped a Jinja-rendered `uv.lock` (its `requires-python` line contains `{{python_version}}`), so every template update re-rendered the lockfile and collided with the dependencies the project had added since generation. Users also had to open the README to find the setup commands after generation.

## Related Issues

None

## Implementation Approach

Both changes are Copier configuration only, in `copier.yml`:

- `_skip_if_exists: [uv.lock]` tells Copier to render `uv.lock` only when it does not exist yet. On first generation the lockfile is still created, and if a project deleted it, an update recreates it. Other files (README, `main.py`, `src/`, `tests/`) keep the normal three-way merge on update so template improvements still reach them.
- `_message_after_copy` prints the same setup and check commands the README documents, using `_copier_conf.dst_path` for the `cd` target.

## Changes

- `copier.yml`: `uv.lock` is skipped when it already exists in the destination.
- `copier.yml`: a post-copy message lists `cd`, `uv sync --locked`, `uv run pre-commit install`, and the Ruff / ty / pytest commands.

## Impact

- User-facing: existing generated projects keep their own `uv.lock` on the next `copier update`. New projects see the next-steps message after generation.
- Compatibility: no change to generated file contents. The message is informational only and does not run anything.
- CI, Docker, and devcontainer configuration are unaffected.

## Validation Results

Generated a project from this branch, edited `uv.lock` and `README.md`, then re-ran `copier copy --overwrite` into the same directory. `uv.lock` was skipped and kept the edit, while `README.md` was overwritten as before. The post-copy message was printed after the first copy.

```bash
uvx copier copy --vcs-ref HEAD --defaults -d project_name=demo -d package_name=demo \
  -d description=demo -d author_name=t -d author_email=t@example.com . /tmp/demo
# ... "Your project "demo" has been created successfully!" + next steps
echo "# user edit" >> /tmp/demo/uv.lock; echo "# user edit" >> /tmp/demo/README.md
uvx copier copy --vcs-ref HEAD --defaults --overwrite -d project_name=demo -d package_name=demo \
  -d description=demo -d author_name=t -d author_email=t@example.com . /tmp/demo
#   conflict  uv.lock
#       skip  uv.lock
#   conflict  README.md
#  overwrite  README.md
grep -c "# user edit" /tmp/demo/uv.lock    # 1
grep -c "# user edit" /tmp/demo/README.md  # 0
```
