### PR TITLE
chore: tighten the Ruff rule set and format docstring code

### DIFF
--- a/template/pyproject.toml
+++ b/template/pyproject.toml
@@ -22,25 +22,31 @@ line-length = 100
 target-version = "py{{python_version | replace('.', '')}}"
 exclude = [".git", ".ruff_cache", ".venv", ".vscode"]
 
+[tool.ruff.format]
+docstring-code-format = true
+
 [tool.ruff.lint]
 select = [
-    "ANN", # type annotation
-    "B",   # flake8-bugbear
-    "D",   # pydocstyle
-    "E",   # pycodestyle errors
-    "F",   # pyflakes
-    "I",   # isort
-    "PTH", # use `pathlib.Path` instead of `os.path`
-    "RUF", # ruff specific rules
-    "SIM", # flake8-simplify
-    "UP",  # pyupgrade
-    "W",   # pycodestyle warnings
+    "ANN",  # type annotation
+    "B",    # flake8-bugbear
+    "C4",   # flake8-comprehensions
+    "D",    # pydocstyle
+    "E",    # pycodestyle errors
+    "F",    # pyflakes
+    "FURB", # refurb
+    "I",    # isort
+    "PERF", # perflint
+    "PT",   # flake8-pytest-style
+    "PTH",  # use `pathlib.Path` instead of `os.path`
+    "RUF",  # ruff specific rules
+    "SIM",  # flake8-simplify
+    "TC",   # flake8-type-checking
+    "UP",   # pyupgrade
+    "W",    # pycodestyle warnings
 ]
 ignore = [
     "ANN401", # Checks that function arguments are annotated with a more specific type than Any.
     "B905",   # `zip()` without `strict=True`
-    "COM812", # Missing trailing comma
-    "COM819", # Trailing comma prohibited
     "D100",   # Missing docstring in public module
     "D203",   # One blank line required before class docstring (ignored because D211 is prioritized in pydocstyle convention 'google')
     "D205",   # 1 blank line required between summary line and description
@@ -49,13 +55,7 @@ ignore = [
     "D400",   # First line of docstring should end with a period
     "D415",   # First line of docstring should end with punctuation (period, question mark, or exclamation point)
     "E114",   # Indentation is not a multiple of four (comment)
-    "G004",   # Logging statement uses f-string
-    "ISC001", # Implicit string concatenation on a single line
-    "ISC002", # Implicit string concatenation on multiple lines
     "PTH123", # `open()` should be replaced by `Path.open()`
-    "Q000",   # Single quotes found when double quotes are preferred
-    "Q001",   # Single quotes found when double quotes are preferred for multi-line strings
-    "Q002",   # Single quotes found when double quotes are preferred for docstrings
     "RUF002", # Checks for ambiguous Unicode characters in docstrings.
     "RUF003", # Checks for ambiguous Unicode characters in comments.
     "SIM105", # try-except-pass blocks that can be replaced with the contextlib.suppress context manager.


### PR DESCRIPTION
## Overview and Background

The Ruff configuration in generated projects now selects five more rule families, formats code examples inside docstrings, and no longer carries ignore entries for rules that were never enabled. Previously the `ignore` list contained COM812, COM819, G004, ISC001, ISC002, Q000, Q001 and Q002 even though the COM, G, ISC and Q families were not in `select`, so those lines suggested behavior that did not exist. Common pytest, comprehension, and performance mistakes also went unreported.

## Related Issues

None

## Implementation Approach

- Added families: `C4` (flake8-comprehensions), `FURB` (refurb), `PERF` (perflint), `PT` (flake8-pytest-style), `TC` (flake8-type-checking). Each targets a class of issue the existing set did not cover, and none conflict with the Ruff formatter. Only stable rules in each family are enabled because `preview` stays off.
- Removed the eight ignore entries whose families are not selected. Entries for selected families (ANN, B, D, E, PTH, RUF, SIM) are untouched.
- `[tool.ruff.format] docstring-code-format = true` formats fenced or doctest code in docstrings with the same style as the source.
- Comments in the `select` list are re-aligned for the four-letter codes; no other formatting changed.

## Changes

- `template/pyproject.toml`: `select` gains C4, FURB, PERF, PT, TC; `ignore` drops COM812, COM819, G004, ISC001, ISC002, Q000, Q001, Q002; new `[tool.ruff.format]` table.

## Impact

- User-facing: `ruff check` in generated projects reports more issues. The example package and tests in the template pass without changes.
- Compatibility: projects updating from the template may see new findings after `copier update`; most rules in the added families have auto-fixes (`ruff check --fix`).
- The lockfile, CI, Docker, and devcontainer are unchanged (Ruff is already at 0.16.6).

## Validation Results

Rendered the new `pyproject.toml` into a generated Python 3.10 project and ran Ruff.

```bash
uv run --frozen ruff check .                 # All checks passed!
uv run --frozen ruff format . --check        # 7 files already formatted
uv run --frozen ruff check . 2>&1 | grep -i warn   # (none: no unknown or deprecated rule codes)
```
