### PR TITLE
feat: move containers to Ubuntu 26.04 and install uv from the Dockerfile

### DIFF
--- a/template/.devcontainer/Dockerfile
+++ b/template/.devcontainer/Dockerfile
@@ -1,6 +1,10 @@
 # syntax=docker/dockerfile:1
 
-FROM mcr.microsoft.com/devcontainers/base:ubuntu-24.04
+FROM ghcr.io/astral-sh/uv:0.12.10 AS uv
+
+FROM mcr.microsoft.com/devcontainers/base:resolute
+
+COPY --from=uv /uv /uvx /usr/local/bin/
 
 RUN rm -f /etc/apt/apt.conf.d/docker-clean \
     && echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache

--- a/template/.devcontainer/devcontainer.json
+++ b/template/.devcontainer/devcontainer.json
@@ -20,9 +20,7 @@
 		"ghcr.io/devcontainers/features/common-utils:2": {
 			"configureZshAsDefaultShell": true
 		},
-		"ghcr.io/va-h/devcontainers-features/uv:1": {
-			"shellAutocompletion": true
-		},
+		"ghcr.io/devcontainers/features/node:1": {},
 		"ghcr.io/anthropics/devcontainer-features/claude-code:1.0": {}
 	},
 	"runArgs": [
@@ -40,6 +38,7 @@
 			"extensions": [
 				"ms-python.python",
 				"charliermarsh.ruff",
+				"astral-sh.ty",
 				"eamodio.gitlens",
 				"tamasfe.even-better-toml",
 				"ms-toolsai.jupyter",

--- a/template/docker/Dockerfile
+++ b/template/docker/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1
 
-ARG BUILDER_IMAGE="ubuntu:24.04"
-ARG RUNNER_IMAGE="ubuntu:24.04"
+ARG BUILDER_IMAGE="ubuntu:26.04"
+ARG RUNNER_IMAGE="ubuntu:26.04"
 
 FROM ghcr.io/astral-sh/uv:0.12.10 AS uv
 

--- a/template/docker/build.sh
+++ b/template/docker/build.sh
@@ -4,8 +4,8 @@ set -euo pipefail
 
 cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.."
 
-BUILDER_IMAGE="ubuntu:24.04"
-RUNNER_IMAGE="ubuntu:24.04"
+BUILDER_IMAGE="ubuntu:26.04"
+RUNNER_IMAGE="ubuntu:26.04"
 IMAGE_NAME="$(basename -- "$PWD" | tr '[:upper:]' '[:lower:]')"
 
 exec docker build \

--- a/template/docker/entrypoint.sh
+++ b/template/docker/entrypoint.sh
@@ -7,7 +7,7 @@ GROUP_ID="${GROUP_ID:-1000}"
 USER_NAME="${USER_NAME:-user}"
 GROUP_NAME="${GROUP_NAME:-group}"
 
-userdel -r ubuntu >/dev/null 2>&1 || true # For Ubuntu 24.04 image
+userdel -r ubuntu >/dev/null 2>&1 || true # Ubuntu images ship a default "ubuntu" user with UID 1000
 groupadd -g "${GROUP_ID}" "${GROUP_NAME}" >/dev/null 2>&1 || true
 useradd -u "${USER_ID}" -g "${GROUP_NAME}" -G sudo -o -m "${USER_NAME}" >/dev/null 2>&1 || true
 


### PR DESCRIPTION
## Overview and Background

Generated projects now build their Docker image and dev container on Ubuntu 26.04 LTS, install uv in the dev container from the pinned uv image, and ship the ty VS Code extension. Previously both images were on Ubuntu 24.04, the dev container took uv from a community feature (`ghcr.io/va-h/devcontainers-features/uv`) whose version was not tracked by Dependabot, and the editor had no ty integration even though the project type-checks with ty.

## Related Issues

None

## Implementation Approach

- Docker: only the `ARG` defaults in `docker/Dockerfile` and the matching variables in `docker/build.sh` change to `ubuntu:26.04`. The entrypoint's `userdel ubuntu` already applies to any Ubuntu image with the default user, so its comment is generalised.
- Dev container: `mcr.microsoft.com/devcontainers/base` has no `ubuntu-26.04` tag yet, so the codename tag `resolute` is used (verified to report `VERSION_ID="26.04"`). uv and uvx are copied from a `FROM ghcr.io/astral-sh/uv:0.12.10 AS uv` stage, the same pattern as `docker/Dockerfile`, so both Dockerfiles pin one uv version that Dependabot's docker ecosystem (#28) keeps current. The uv feature is removed; its shell completion option is dropped with it.
- `astral-sh.ty` is added next to the Ruff extension so the editor shows the same diagnostics as `ty check`.
- The Claude Code feature installs Node.js itself when none is present, but on Ubuntu 26.04 that fallback fails (the NodeSource 18.x repository does not serve `resolute`, and the distro `nodejs` package lacks npm). Following the feature's own error message, `ghcr.io/devcontainers/features/node:1` is declared explicitly so Node.js LTS is installed before Claude Code.

## Changes

- `template/docker/Dockerfile`, `template/docker/build.sh`: Ubuntu 26.04 defaults.
- `template/docker/entrypoint.sh`: comment only.
- `template/.devcontainer/Dockerfile`: `resolute` base, uv/uvx copied from the pinned uv image.
- `template/.devcontainer/devcontainer.json`: uv feature removed, Node.js feature added, ty extension added.

## Impact

- User-facing: rebuilding the Docker image or dev container pulls Ubuntu 26.04. `run.sh`, Compose, and the CI workflow are unchanged.
- Compatibility: uv's `UV_PYTHON_PREFERENCE=only-managed` means Python comes from uv, not the OS, so the Ubuntu upgrade does not change the interpreter. Shell autocompletion for uv that the feature provided is no longer installed.
- Dependabot: the dev container base is a codename tag, so Dependabot will not propose `ubuntu-26.04` automatically; the uv stage is tracked.

## Validation Results

Generated a Python 3.14 project from this branch and built both images locally.

```bash
# Application image via the template scripts
./docker/build.sh
./docker/run.sh bash -c 'grep VERSION_ID /etc/os-release; id; uv --version; python --version; python main.py'
# VERSION_ID="26.04"
# uid=501(mjun) gid=50(staff) groups=50(staff),27(sudo)
# uv 0.12.10 (aarch64-unknown-linux-musl)
# Python 3.14.7
# Hello from test-copier!

# Dev container image
docker build -f .devcontainer/Dockerfile -t demo-devc-test .
docker run --rm demo-devc-test bash -c 'grep VERSION_ID /etc/os-release; uv --version; uvx --version; codex --version; rg --version | head -1; fdfind --version'
# VERSION_ID="26.04"
# uv 0.12.10 / uvx 0.12.10
# codex-cli 0.153.4
# ripgrep 15.1.0
# fdfind 10.3.0
```

Full dev container build with all features via the Dev Container CLI:

```bash
npx -y @devcontainers/cli build --workspace-folder . --image-name demo-devc-full
docker run --rm --user vscode demo-devc-full bash -lc 'grep VERSION_ID /etc/os-release; node --version; claude --version; uv --version; codex --version; gh --version | head -1'
# VERSION_ID="26.04"
# v24.20.0
# 2.1.263 (Claude Code)
# uv 0.12.10 (aarch64-unknown-linux-musl)
# codex-cli 0.153.4
# gh version 2.100.0
```

The first CI run of this PR failed exactly on the Claude Code feature's Node.js fallback; the Node.js feature above is the fix.
