### PR TITLE
feat: add a console script entry point and a license prompt

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,7 +48,8 @@ jobs:
             -d package_name=test_copier \
             -d description="Test Copier" \
             -d author_name=test-copier \
-            -d author_email=test-copier@example.com
+            -d author_email=test-copier@example.com \
+            -d license=MIT
 
       - name: Test Package Installation
         working-directory: /tmp/test-copier
@@ -74,6 +75,12 @@ jobs:
         working-directory: /tmp/test-copier
         run: |
           uv run --frozen pytest -vs --cov
+
+      - name: Test console script
+        working-directory: /tmp/test-copier
+        run: |
+          test -f LICENSE
+          uv run --frozen test-copier
 
       - name: Test Docker
         working-directory: /tmp/test-copier

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Follow the interactive prompts to configure your project:
 - **Description**: A short description of your project
 - **Author name**: Your name
 - **Author email**: Your email address
+- **License**: MIT, Apache-2.0, BSD-3-Clause, or None (no LICENSE file)
 
 ### Development Setup
 
@@ -55,6 +56,9 @@ uv sync
 
 # Install git hooks
 uv run prek install
+
+# Run the application
+uv run your-project-name
 
 # Run tests
 uv run pytest

--- a/copier.yml
+++ b/copier.yml
@@ -2,6 +2,7 @@ _templates_suffix: ""
 _subdirectory: template
 _skip_if_exists:
   - uv.lock
+  - LICENSE
 _message_after_copy: |
   Your project "{{ project_name }}" has been created successfully!
 
@@ -73,3 +74,13 @@ author_email:
     {% if not author_email or author_email.strip() == '' %}
     Author email cannot be empty
     {% endif %}
+
+license:
+  type: str
+  default: MIT
+  help: Which license do you want to use? Choose None to keep the project unlicensed.
+  choices:
+    - MIT
+    - Apache-2.0
+    - BSD-3-Clause
+    - None

--- a/template/README.md
+++ b/template/README.md
@@ -15,6 +15,9 @@ uv sync --locked
 # Install git hooks
 uv run prek install
 
+# Run the application
+uv run {{project_name}}
+
 # Run tests
 uv run pytest
 # Run tests with coverage

--- a/template/main.py
+++ b/template/main.py
@@ -1,10 +1,4 @@
-from {{package_name}} import hello
-
-
-def main() -> None:
-    """Print the greeting for the generated project."""
-    print(hello())
-
+from {{package_name}}.__main__ import main
 
 if __name__ == "__main__":
     main()

--- a/template/pyproject.toml
+++ b/template/pyproject.toml
@@ -4,8 +4,15 @@ version = "0.0.1"
 description = "{{description}}"
 readme = "README.md"
 authors = [{ name = "{{author_name}}", email = "{{author_email}}" }]
+{% if license != 'None' -%}
+license = "{{license}}"
+license-files = ["LICENSE"]
+{% endif -%}
 requires-python = ">={{python_version}}"
 dependencies = []
+
+[project.scripts]
+"{{project_name}}" = "{{package_name}}.__main__:main"
 
 [build-system]
 requires = ["hatchling"]
@@ -85,3 +92,4 @@ branch = true
 [tool.coverage.report]
 fail_under = 80
 show_missing = true
+exclude_also = ['if __name__ == "__main__":']

--- a/template/src/{{package_name}}/__main__.py
+++ b/template/src/{{package_name}}/__main__.py
@@ -1,0 +1,12 @@
+"""Command-line entry point for {{project_name}}."""
+
+from {{package_name}} import hello
+
+
+def main() -> None:
+    """Print the greeting for the generated project."""
+    print(hello())
+
+
+if __name__ == "__main__":
+    main()

--- a/template/tests/test_main.py
+++ b/template/tests/test_main.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from {{package_name}}.__main__ import main
+
+if TYPE_CHECKING:
+    import pytest
+
+
+def test_main_prints_greeting(capsys: pytest.CaptureFixture[str]) -> None:
+    """Test that main prints the project greeting."""
+    main()
+    assert capsys.readouterr().out == "Hello from {{project_name}}!\n"

--- a/template/{% if license != 'None' %}LICENSE{% endif %}
+++ b/template/{% if license != 'None' %}LICENSE{% endif %}
@@ -1,0 +1,106 @@
+{% if license == 'MIT' -%}
+MIT License
+
+Copyright (c) {{ '%Y' | strftime }} {{ author_name }}
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+associated documentation files (the "Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the
+following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial
+portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT
+LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO
+EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+USE OR OTHER DEALINGS IN THE SOFTWARE.
+{% elif license == 'Apache-2.0' -%}
+Apache License
+Version 2.0, January 2004
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+"License" shall mean the terms and conditions for use, reproduction, and distribution as defined by Sections 1 through 9 of this document.
+
+"Licensor" shall mean the copyright owner or entity authorized by the copyright owner that is granting the License.
+
+"Legal Entity" shall mean the union of the acting entity and all other entities that control, are controlled by, or are under common control with that entity. For the purposes of this definition, "control" means (i) the power, direct or indirect, to cause the direction or management of such entity, whether by contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the outstanding shares, or (iii) beneficial ownership of such entity.
+
+"You" (or "Your") shall mean an individual or Legal Entity exercising permissions granted by this License.
+
+"Source" form shall mean the preferred form for making modifications, including but not limited to software source code, documentation source, and configuration files.
+
+"Object" form shall mean any form resulting from mechanical transformation or translation of a Source form, including but not limited to compiled object code, generated documentation, and conversions to other media types.
+
+"Work" shall mean the work of authorship, whether in Source or Object form, made available under the License, as indicated by a copyright notice that is included in or attached to the work (an example is provided in the Appendix below).
+
+"Derivative Works" shall mean any work, whether in Source or Object form, that is based on (or derived from) the Work and for which the editorial revisions, annotations, elaborations, or other modifications represent, as a whole, an original work of authorship. For the purposes of this License, Derivative Works shall not include works that remain separable from, or merely link (or bind by name) to the interfaces of, the Work and Derivative Works thereof.
+
+"Contribution" shall mean any work of authorship, including the original version of the Work and any modifications or additions to that Work or Derivative Works thereof, that is intentionally submitted to Licensor for inclusion in the Work by the copyright owner or by an individual or Legal Entity authorized to submit on behalf of the copyright owner. For the purposes of this definition, "submitted" means any form of electronic, verbal, or written communication sent to the Licensor or its representatives, including but not limited to communication on electronic mailing lists, source code control systems, and issue tracking systems that are managed by, or on behalf of, the Licensor for the purpose of discussing and improving the Work, but excluding communication that is conspicuously marked or otherwise designated in writing by the copyright owner as "Not a Contribution."
+
+"Contributor" shall mean Licensor and any individual or Legal Entity on behalf of whom a Contribution has been received by Licensor and subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license to reproduce, prepare Derivative Works of, publicly display, publicly perform, sublicense, and distribute the Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as stated in this section) patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer the Work, where such license applies only to those patent claims licensable by such Contributor that are necessarily infringed by their Contribution(s) alone or by combination of their Contribution(s) with the Work to which such Contribution(s) was submitted. If You institute patent litigation against any entity (including a cross-claim or counterclaim in a lawsuit) alleging that the Work or a Contribution incorporated within the Work constitutes direct or contributory patent infringement, then any patent licenses granted to You under this License for that Work shall terminate as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the Work or Derivative Works thereof in any medium, with or without modifications, and in Source or Object form, provided that You meet the following conditions:
+
+     (a) You must give any other recipients of the Work or Derivative Works a copy of this License; and
+
+     (b) You must cause any modified files to carry prominent notices stating that You changed the files; and
+
+     (c) You must retain, in the Source form of any Derivative Works that You distribute, all copyright, patent, trademark, and attribution notices from the Source form of the Work, excluding those notices that do not pertain to any part of the Derivative Works; and
+
+     (d) If the Work includes a "NOTICE" text file as part of its distribution, then any Derivative Works that You distribute must include a readable copy of the attribution notices contained within such NOTICE file, excluding those notices that do not pertain to any part of the Derivative Works, in at least one of the following places: within a NOTICE text file distributed as part of the Derivative Works; within the Source form or documentation, if provided along with the Derivative Works; or, within a display generated by the Derivative Works, if and wherever such third-party notices normally appear. The contents of the NOTICE file are for informational purposes only and do not modify the License. You may add Your own attribution notices within Derivative Works that You distribute, alongside or as an addendum to the NOTICE text from the Work, provided that such additional attribution notices cannot be construed as modifying the License.
+
+     You may add Your own copyright statement to Your modifications and may provide additional or different license terms and conditions for use, reproduction, or distribution of Your modifications, or for any such Derivative Works as a whole, provided Your use, reproduction, and distribution of the Work otherwise complies with the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise, any Contribution intentionally submitted for inclusion in the Work by You to the Licensor shall be under the terms and conditions of this License, without any additional terms or conditions. Notwithstanding the above, nothing herein shall supersede or modify the terms of any separate license agreement you may have executed with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade names, trademarks, service marks, or product names of the Licensor, except as required for reasonable and customary use in describing the origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or agreed to in writing, Licensor provides the Work (and each Contributor provides its Contributions) on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied, including, without limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. You are solely responsible for determining the appropriateness of using or redistributing the Work and assume any risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory, whether in tort (including negligence), contract, or otherwise, unless required by applicable law (such as deliberate and grossly negligent acts) or agreed to in writing, shall any Contributor be liable to You for damages, including any direct, indirect, special, incidental, or consequential damages of any character arising as a result of this License or out of the use or inability to use the Work (including but not limited to damages for loss of goodwill, work stoppage, computer failure or malfunction, or any and all other commercial damages or losses), even if such Contributor has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing the Work or Derivative Works thereof, You may choose to offer, and charge a fee for, acceptance of support, warranty, indemnity, or other liability obligations and/or rights consistent with this License. However, in accepting such obligations, You may act only on Your own behalf and on Your sole responsibility, not on behalf of any other Contributor, and only if You agree to indemnify, defend, and hold each Contributor harmless for any liability incurred by, or claims asserted against, such Contributor by reason of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+To apply the Apache License to your work, attach the following boilerplate notice, with the fields enclosed by brackets "[]" replaced with your own identifying information. (Don't include the brackets!)  The text should be enclosed in the appropriate comment syntax for the file format. We also recommend that a file or class name and description of purpose be included on the same "printed page" as the copyright notice for easier identification within third-party archives.
+
+Copyright {{ '%Y' | strftime }} {{ author_name }}
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+{% elif license == 'BSD-3-Clause' -%}
+Copyright (c) {{ '%Y' | strftime }} {{ author_name }}.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+{% endif -%}


### PR DESCRIPTION
## Overview and Background

Generated projects now expose a console script named after the project, so `uv run <project_name>` (and `python -m <package_name>`) runs the application, and generation asks which license to use, writing a LICENSE file and the PEP 639 metadata to match. Previously the only entry point was the root `main.py`, which is not installed with the package and cannot be invoked after `uv build`, and projects were generated without any license file or `license` metadata, leaving the built wheel without licensing information.

## Related Issues

None

## Implementation Approach

- Entry point: the greeting logic moves into `src/<package>/__main__.py` with a `main()` function. `[project.scripts]` registers `"<project_name>" = "<package>.__main__:main"` (the key is quoted because project names may contain dots), and the root `main.py` is kept as a thin delegate so existing instructions and the Compose command keep working. The `if __name__ == "__main__":` guard is excluded from coverage.
- License: a new `license` prompt offers MIT, Apache-2.0, BSD-3-Clause, or None (default MIT). The LICENSE template embeds the canonical SPDX texts and fills the year with Copier's `strftime` filter and the holder with `author_name`. For None the file name renders empty, which Copier treats as "do not create". LICENSE is added to `_skip_if_exists` so `copier update` never rewrites a license a project has customised or re-dated.
- `pyproject.toml` gets `license = "<SPDX id>"` and `license-files = ["LICENSE"]` only when a license was chosen; hatchling emits these as `License-Expression` and `License-File` in the wheel metadata.
- The new test uses `from __future__ import annotations` with a `TYPE_CHECKING` import of pytest, which satisfies the `TC` rules on every supported target version (with the py314 target, Ruff otherwise reports TC002).

## Changes

- `copier.yml`: `license` prompt; `LICENSE` in `_skip_if_exists`.
- `template/{% if license != 'None' %}LICENSE{% endif %}`: MIT / Apache-2.0 / BSD-3-Clause texts.
- `template/pyproject.toml`: conditional `license` and `license-files`; `[project.scripts]`; coverage `exclude_also`.
- `template/src/{{package_name}}/__main__.py`: `main()`; `template/main.py` delegates to it.
- `template/tests/test_main.py`: captures the greeting printed by `main()`.
- `.github/workflows/test.yml`: passes `license=MIT`, asserts the LICENSE file exists, and runs the console script.
- `README.md`, `template/README.md`: document the prompt and `uv run <project_name>`.

## Impact

- User-facing: one more prompt during generation (default MIT). `uv run <project_name>` and `python -m <package_name>` are new; `python main.py` and `docker compose up` behave as before.
- Compatibility: projects updating from the template receive the new prompt with its default unless answered; because LICENSE is in `_skip_if_exists`, an existing LICENSE is never overwritten. The lockfile is unaffected (`uv sync --locked` passes with the new metadata).
- Packaging: wheels and sdists now carry the license expression and file.

## Validation Results

Generated projects from this branch for each license choice and for Python 3.10 and 3.14.

```bash
# Each license choice
for lic in MIT Apache-2.0 BSD-3-Clause None; do uvx copier copy --defaults ... -d license=$lic . out-$lic; done
# MIT / Apache-2.0 / BSD-3-Clause: LICENSE present with "2026 <author>", pyproject has license + license-files
# None: no LICENSE file, no license keys in pyproject

# Python 3.10 and 3.14 projects (MIT)
uv sync --locked
uv run --frozen ruff format . --check    # 8 files already formatted
uv run --frozen ruff check .             # All checks passed!
uv run --frozen ty check                 # All checks passed!
uv run --frozen pytest --cov             # 3 passed, coverage 100% (__init__ 2/2, __main__ 3/3)
uv run --frozen test-copier              # Hello from test-copier!
uv run --frozen python -m test_copier    # Hello from test-copier!
uv run --frozen python main.py           # Hello from test-copier!

# Wheel metadata
uv build
unzip -p dist/*.whl '*/METADATA' | grep -E '^License'
# License-Expression: MIT
# License-File: LICENSE
unzip -l dist/*.whl | grep -i license    # test_copier-0.0.1.dist-info/licenses/LICENSE
```
