### PR TITLE
feat: install Claude Code with its native installer in dev containers

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,8 +94,8 @@ docker compose up
 ### VS Code Devcontainer
 
 Open the project in VS Code and use the "Reopen in Container" command for a fully configured development environment.
-Devcontainer will automatically install uv, Claude Code, and git hooks. The image build installs the latest
-Codex release, so rebuilding the image updates Codex.
+Devcontainer will automatically install uv, Claude Code, Codex, and git hooks. The image build installs the
+latest Claude Code and Codex releases with their official installers, so rebuilding the image updates both.
 
 The container mounts the host `${HOME}/.claude` and `${HOME}/.codex` directories at `/home/vscode/.claude` and
 `/home/vscode/.codex` for authentication. These bind mounts are read-write, so changes made in the container can

--- a/template/.devcontainer/Dockerfile
+++ b/template/.devcontainer/Dockerfile
@@ -26,3 +26,10 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
         CODEX_NON_INTERACTIVE=1 \
         sh /tmp/install-codex.sh \
     && rm -f /tmp/install-codex.sh
+
+# Claude Code's native installer installs under $HOME, so run it as the container user
+USER vscode
+RUN curl -fsSL https://claude.ai/install.sh | bash \
+    && rm -rf /home/vscode/.claude/downloads
+USER root
+RUN ln -s /home/vscode/.local/bin/claude /usr/local/bin/claude

--- a/template/.devcontainer/devcontainer.json
+++ b/template/.devcontainer/devcontainer.json
@@ -19,9 +19,7 @@
 		"ghcr.io/devcontainers/features/github-cli:1": {},
 		"ghcr.io/devcontainers/features/common-utils:2": {
 			"configureZshAsDefaultShell": true
-		},
-		"ghcr.io/devcontainers/features/node:1": {},
-		"ghcr.io/anthropics/devcontainer-features/claude-code:1.0": {}
+		}
 	},
 	"runArgs": [
 		"--init",

--- a/template/README.md
+++ b/template/README.md
@@ -47,8 +47,8 @@ docker compose up
 ### VS Code Devcontainer
 
 Open the project in VS Code and use the "Reopen in Container" command for a fully configured development environment.
-Devcontainer automatically installs uv and Claude Code, and installs the latest Codex release when the image is built.
-Rebuild the image to update Codex.
+Devcontainer automatically installs uv, Claude Code, and Codex. The latest Claude Code and Codex releases are
+installed with their official installers when the image is built, so rebuild the image to update them.
 
 The container mounts the host `${HOME}/.claude` and `${HOME}/.codex` directories at `/home/vscode/.claude` and
 `/home/vscode/.codex` for authentication. These bind mounts are read-write, so changes made in the container can


### PR DESCRIPTION
## Overview and Background

The generated dev container now installs Claude Code with Anthropic's native installer during the image build and no longer contains Node.js. Previously Claude Code came from the `ghcr.io/anthropics/devcontainer-features/claude-code` feature, which installs the npm package and therefore needs Node.js. On Ubuntu 26.04 the feature's own Node.js fallback failed, so #33 had to add the `node` feature explicitly, reintroducing a runtime that #19 had deliberately removed when Codex switched to its standalone installer.

## Related Issues

None. Follows up on #33 and restores the intent of #19.

## Implementation Approach

- The native installer (`curl -fsSL https://claude.ai/install.sh | bash`) downloads a checksum-verified binary and installs it under `$HOME` (`~/.local/share/claude/versions/<v>` with a `~/.local/bin/claude` launcher). It is run as the `vscode` user in the Dockerfile so the files belong to the user that will run it; the transient `~/.claude/downloads` directory is removed afterwards.
- `/usr/local/bin/claude` is a symlink to the user's launcher so the command works from `bash -lc`, `zsh -lc`, and non-login shells without relying on rc files that the `common-utils` feature rewrites.
- The `claude-code` and `node` features are removed from `devcontainer.json`. `github-cli` and `common-utils` stay.
- The host `~/.claude` bind mount (authentication and config) is unaffected: the binary lives in `~/.local`, and the image was verified with an empty `~/.claude` mounted over it.

## Changes

- `template/.devcontainer/Dockerfile`: native Claude Code install as `vscode`, symlink in `/usr/local/bin`.
- `template/.devcontainer/devcontainer.json`: `node` and `claude-code` features removed.
- `README.md`, `template/README.md`: rebuilding the image updates both Claude Code and Codex.

## Impact

- User-facing: `claude` is available exactly as before. The image no longer ships Node.js or npm; projects that need Node.js for their own work should add the `node` feature themselves.
- Updates: Claude Code is fetched at image build time (latest release), the same policy as Codex. The native binary can also self-update inside a running container because it owns `~/.local/share/claude`.
- Build time: the feature step that installed Node.js and the npm package is replaced by a single binary download.

## Validation Results

Generated a Python 3.14 project from this branch and built the dev container both with plain Docker and with the Dev Container CLI (features included).

```bash
# Plain Dockerfile build; empty ~/.claude mounted to mimic the host bind mount
docker build -f .devcontainer/Dockerfile -t demo-cc-plain .
docker run --rm --user vscode --tmpfs /home/vscode/.claude demo-cc-plain bash -c \
  'claude --version; readlink -f /usr/local/bin/claude; command -v node || echo "node: absent"'
# 2.1.263 (Claude Code)
# /home/vscode/.local/share/claude/versions/2.1.263
# node: absent
docker run --rm demo-cc-plain bash -c 'claude --version'   # 2.1.263 (Claude Code) as root too

# Full build with features
npx -y @devcontainers/cli build --workspace-folder . --image-name demo-cc-full
docker run --rm --user vscode --tmpfs /home/vscode/.claude demo-cc-full zsh -lc \
  'claude --version; gh --version | head -1; command -v node || echo "node: absent"'
# 2.1.263 (Claude Code) / gh version 2.100.0 / node: absent
docker run --rm --user vscode demo-cc-full bash -lc 'claude --version; codex --version; uv --version'
# 2.1.263 (Claude Code) / codex-cli 0.153.4 / uv 0.12.10
```
