### PR TITLE
feat: run pytest in parallel with pytest-xdist by default

### DIFF
--- a/template/pyproject.toml
+++ b/template/pyproject.toml
@@ -22,7 +22,14 @@ build-backend = "hatchling.build"
 packages = ["src/{{package_name}}"]
 
 [dependency-groups]
-dev = ["prek>=0.5.2", "pytest>=9.1.1", "pytest-cov>=7.1.0", "ruff>=0.16.6", "ty>=0.0.78"]
+dev = [
+    "prek>=0.5.2",
+    "pytest>=9.1.1",
+    "pytest-cov>=7.1.0",
+    "pytest-xdist>=3.8.0",
+    "ruff>=0.16.6",
+    "ty>=0.0.78",
+]
 
 [tool.ruff]
 line-length = 100
@@ -82,7 +89,7 @@ convention = "google"
 
 [tool.pytest]
 testpaths = ["tests"]
-addopts = ["-ra", "--strict-markers", "--strict-config"]
+addopts = ["-ra", "--strict-markers", "--strict-config", "--numprocesses=auto"]
 xfail_strict = true
 
 [tool.coverage.run]

--- a/template/uv.lock
+++ b/template/uv.lock
@@ -154,6 +154,7 @@ dev = [
     { name = "prek" },
     { name = "pytest" },
     { name = "pytest-cov" },
+    { name = "pytest-xdist" },
     { name = "ruff" },
     { name = "ty" },
 ]
@@ -165,6 +166,7 @@ dev = [
     { name = "prek", specifier = ">=0.5.2" },
     { name = "pytest", specifier = ">=9.1.1" },
     { name = "pytest-cov", specifier = ">=7.1.0" },
+    { name = "pytest-xdist", specifier = ">=3.8.0" },
     { name = "ruff", specifier = ">=0.16.6" },
     { name = "ty", specifier = ">=0.0.78" },
 ]
@@ -179,6 +181,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8a/0e/97c33bf5009bdbac74fd2beace167cab3f978feb69cc36f1ef79360d6c4e/exceptiongroup-1.3.1-py3-none-any.whl", hash = "sha256:a7a39a3bd276781e98394987d3a5701d0c4edffb633bb7a5144577f82c773598", size = 16740, upload-time = "2025-11-21T23:01:53.443Z" },
+]
+
+[[package]]
+name = "execnet"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/89/780e11f9588d9e7128a3f87788354c7946a9cbb1401ad38a48c4db9a4f07/execnet-2.1.2.tar.gz", hash = "sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd", size = 166622, upload-time = "2025-11-12T09:56:37.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/84/02fc1827e8cdded4aa65baef11296a9bbe595c474f0d6d758af082d849fd/execnet-2.1.2-py3-none-any.whl", hash = "sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec", size = 40708, upload-time = "2025-11-12T09:56:36.333Z" },
 ]
 
 [[package]]
@@ -263,6 +274,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b1/51/a849f96e117386044471c8ec2bd6cfebacda285da9525c9106aeb28da671/pytest_cov-7.1.0.tar.gz", hash = "sha256:30674f2b5f6351aa09702a9c8c364f6a01c27aae0c1366ae8016160d1efc56b2", size = 55592, upload-time = "2026-03-21T20:11:16.284Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl", hash = "sha256:a0461110b7865f9a271aa1b51e516c9a95de9d696734a2f71e3e78f46e1d4678", size = 22876, upload-time = "2026-03-21T20:11:14.438Z" },
+]
+
+[[package]]
+name = "pytest-xdist"
+version = "3.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "execnet" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/b4/439b179d1ff526791eb921115fca8e44e596a13efeda518b9d845a619450/pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1", size = 88069, upload-time = "2025-07-01T13:30:59.346Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/31/d4e37e9e550c2b92a9cbc2e4d0b7420a27224968580b5a447f420847c975/pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88", size = 46396, upload-time = "2025-07-01T13:30:56.632Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Overview and Background

Generated projects now run their test suite in parallel by default: `pytest` distributes tests across all CPU cores through pytest-xdist. Previously tests ran serially, so suites that grow beyond the template's three example tests paid the full wall-clock cost in CI and in agent-driven edit/test loops.

## Related Issues

None

## Implementation Approach

- `pytest-xdist>=3.8.0` joins the dev dependency group and `uv.lock` is regenerated (adds pytest-xdist and its execnet dependency).
- `--numprocesses=auto` is appended to `[tool.pytest] addopts`, so it applies to every invocation without changing the CI commands. The long option name is used for readability in TOML.
- pytest-cov supports xdist natively, so `pytest --cov` still produces one combined report and enforces the 80% threshold.
- Debugging that needs a single process (`--pdb`, `-s` with interactive input) works by overriding on the command line: `pytest -n 0`.

## Changes

- `template/pyproject.toml`: `pytest-xdist` in the dev group (list reformatted one-per-line as it grew); `--numprocesses=auto` in `addopts`.
- `template/uv.lock`: regenerated.

## Impact

- User-facing: `pytest` output now starts with the worker count line and test order is no longer deterministic across files. Tests that share mutable global state must be made independent or grouped with `@pytest.mark.xdist_group`.
- Tiny suites (like the template's) become slightly slower because workers are spawned (about 0.5s here); real suites get faster.
- Projects updating from the template receive the config change but keep their own `uv.lock` (#27); they need `uv lock` to add pytest-xdist.
- CI workflows are unchanged.

## Validation Results

```bash
# Python 3.10 project rendered from this branch
uv sync --locked
uv run --frozen pytest --cov
# created: 10/10 workers
# 10 workers [3 items]
# TOTAL   5   0   0   0   100%
# Required test coverage of 80.0% reached. Total coverage: 100.00%
# 3 passed in 0.46s

# Python 3.14 project generated with copier copy from HEAD
uv sync --locked
uv run --frozen ruff format . --check && uv run --frozen ruff check . && uv run --frozen ty check
uv run --frozen pytest --cov      # 3 passed, coverage 100% with workers
uv run --frozen pytest -n 0 -q    # 3 passed (single-process override)
```
