### PR TITLE
feat: add shared agent hooks and Claude Code permissions to the template

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ A simple modern Python project template powered by [Copier](https://copier.readt
 - 🐳 **Docker Support**: Complete Docker development environment
 - 📦 **Devcontainer Support**: VS Code devcontainer for consistent development
 - ✨ **AI Editor Support**: [AGENTS.md](https://agents.md) and
-  [CLAUDE.md](https://docs.anthropic.com/en/docs/claude-code/overview) included for AI-powered development
+  [CLAUDE.md](https://docs.anthropic.com/en/docs/claude-code/overview) included for AI-powered development,
+  plus shared Claude Code / Codex hooks that format and lint Python files as the agent edits them
 - 📝 **Type Hints**: Full type annotation support with modern Python features
 - 🔎 **Type Checking**: Pre-configured [ty](https://docs.astral.sh/ty/) for static type checking
 - 🔍 **Code Quality**: Pre-configured Ruff for linting and formatting
@@ -125,6 +126,10 @@ your-project/
 
 - [AGENTS.md(`./template/AGENTS.md`)](https://agents.md)
 - [CLAUDE.md(`./template/CLAUDE.md`)](https://docs.claude.com/en/docs/claude-code/memory#claude-md-imports)
+- `.claude/settings.json`: Claude Code permissions (pre-approved `uv run --frozen`, `uv sync`, read-only git
+  commands; `.env` files denied) and a `PostToolUse` hook
+- `.codex/hooks.json`: the same `PostToolUse` hook for Codex
+- `.agents/hooks/format-python.sh`: the hook script, runs `ruff format` and `ruff check --fix` on the edited file
 
 ## Q&A
 

--- a/template/.agents/hooks/format-python.sh
+++ b/template/.agents/hooks/format-python.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# PostToolUse hook shared by Claude Code and Codex: format and lint the Python
+# files the agent just edited. Reads the hook input JSON from stdin.
+#
+# Claude Code (Edit/Write) reports the file in tool_input.file_path.
+# Codex (apply_patch) reports the whole patch in tool_input.command.
+# Remaining lint errors are sent back to the agent via exit code 2.
+
+set -euo pipefail
+
+input="$(cat)"
+
+files=()
+while IFS= read -r file; do
+	[[ "${file}" == *.py ]] && files+=("${file}")
+done < <(jq -r '
+	(.tool_input.file_path // empty),
+	((.tool_input.command // "") | scan("\\*\\*\\* (?:Add|Update) File: (.+)") | .[0])
+' <<<"${input}")
+
+# Avoid the array-length expansion here: its brace-hash prefix would start a Jinja
+# comment when Copier renders this file.
+[[ -n "${files[*]:-}" ]] || exit 0
+
+cwd="$(jq -r '.cwd // empty' <<<"${input}")"
+cd -- "${cwd:-$(git rev-parse --show-toplevel)}"
+
+uv run --frozen ruff format -- "${files[@]}"
+if ! uv run --frozen ruff check --fix -- "${files[@]}" >&2; then
+	exit 2
+fi

--- a/template/.claude/settings.json
+++ b/template/.claude/settings.json
@@ -1,0 +1,29 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(uv run --frozen *)",
+      "Bash(uv sync *)",
+      "Bash(uv lock *)",
+      "Bash(git status *)",
+      "Bash(git diff *)",
+      "Bash(git log *)"
+    ],
+    "deny": [
+      "Read(.env)",
+      "Read(*.env)"
+    ]
+  },
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$(git rev-parse --show-toplevel)/.agents/hooks/format-python.sh\""
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/template/.codex/hooks.json
+++ b/template/.codex/hooks.json
@@ -1,0 +1,17 @@
+{
+  "description": "Format and lint Python files after the agent edits them.",
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$(git rev-parse --show-toplevel)/.agents/hooks/format-python.sh\"",
+            "statusMessage": "Formatting Python"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/template/.gitignore
+++ b/template/.gitignore
@@ -288,3 +288,7 @@ tags
 .ionide
 
 # End of https://www.toptal.com/developers/gitignore/api/linux,macos,visualstudiocode,vim,python,jupyternotebooks,venv,virtualenv
+
+### AI coding agents ###
+# Personal Claude Code overrides (machine-specific settings, never shared)
+.claude/settings.local.json

--- a/template/AGENTS.md
+++ b/template/AGENTS.md
@@ -9,22 +9,28 @@ Follow these guidelines precisely.
    - ONLY use uv, NEVER pip
    - Installation: `uv add package`
    - Upgrading: `uv add --dev package --upgrade-package package`
-   - FORBIDDEN: `uv pip install`, `@latest` syntax
+   - FORBIDDEN: `uv pip install`, `@latest` syntax, editing `uv.lock` by hand
 
 2. Code Quality
    - Type hints required for all code
+   - Imports used only in type annotations go under `if TYPE_CHECKING:` with
+     `from __future__ import annotations` at the top of the module (Ruff `TC` rules)
    - Follow existing patterns exactly
    - Use Google style for docstring
 
 3. Testing Requirements
-   - Framework: `uv run --frozen pytest`
+   - Framework: `uv run --frozen pytest` (runs in parallel; use `-n 0` for `--pdb`)
    - Coverage: test edge cases and errors
-   - Coverage report: `uv run --frozen pytest --cov`
+   - Coverage report: `uv run --frozen pytest --cov` (CI fails below 80% branch coverage of `src/`)
    - New features require tests
    - Bug fixes require regression tests
 
 4. Git
    - Follow the Conventional Commits style on commit messages.
+   - NEVER use `git commit --no-verify`; fix what the hooks report instead.
+
+5. Running
+   - Application: `uv run {{project_name}}` (or `python -m {{package_name}}`)
 
 ## Code Formatting and Linting
 
@@ -39,3 +45,7 @@ Follow these guidelines precisely.
    - Install: `uv run prek install`
    - Runs: on git commit
    - Tools: uv lock, Ruff, ty
+4. Agent Hooks
+   - `.agents/hooks/format-python.sh` formats and lints every Python file right
+     after Claude Code or Codex edits it (wired in `.claude/settings.json` and
+     `.codex/hooks.json`). Do not re-run the formatter manually after edits.


### PR DESCRIPTION
## Overview and Background

Generated projects now ship a shared agent hook that formats and lints every Python file right after Claude Code or Codex edits it, a committed Claude Code settings file with pre-approved development commands, and an `AGENTS.md` that records the project-specific rules established over the last template changes. Previously the template only provided `AGENTS.md` / `CLAUDE.md` text: agents had to be prompted for every `uv run` invocation, formatting only happened at commit time through prek, and rules such as the `TYPE_CHECKING` import pattern or the coverage threshold lived only in CI failures.

## Related Issues

None

## Implementation Approach

- One script, `.agents/hooks/format-python.sh`, serves both tools because Claude Code and Codex use the same hook event schema (`PostToolUse`, `matcher`, command hooks, exit code 2 = feedback to the agent). The script reads the hook JSON from stdin and collects Python paths from `tool_input.file_path` (Claude Code `Edit`/`Write`) or from the `*** Add File` / `*** Update File` lines of `tool_input.command` (Codex `apply_patch`, which also matches `Edit|Write`). It runs `ruff format` and `ruff check --fix`; diagnostics that cannot be auto-fixed go to stderr with exit code 2 so the agent fixes them itself. Non-Python edits exit 0 immediately. The script changes to the hook's `cwd` (falling back to the git root) so relative paths resolve wherever the agent was started.
- `.claude/settings.json` is the committed, team-wide Claude Code configuration: it wires the hook and pre-approves `uv run --frozen`, `uv sync`, `uv lock` and read-only git commands, while denying `Read` of `.env` files. `.claude/settings.local.json` (personal overrides) is added to the generated `.gitignore`.
- `.codex/hooks.json` wires the same hook for Codex with the documented `hooks.json` shape.
- `AGENTS.md` gains the rules that are otherwise only enforced by tooling: never edit `uv.lock` by hand, the `TYPE_CHECKING` import pattern required by Ruff's `TC` rules, that pytest runs in parallel (`-n 0` for `--pdb`) and CI fails below 80% branch coverage, never `git commit --no-verify`, the run command, and a note that the agent hook already formats edits.

## Changes

- `template/.agents/hooks/format-python.sh`: new hook script (shellcheck and shfmt clean).
- `template/.claude/settings.json`: permissions and `PostToolUse` hook.
- `template/.codex/hooks.json`: `PostToolUse` hook.
- `template/.gitignore`: ignore `.claude/settings.local.json`.
- `template/AGENTS.md`: rules listed above.
- `README.md`: describe the agent configuration files.

## Impact

- User-facing: after an agent edits a `.py` file, the file is formatted immediately and remaining lint errors are fed back to the agent. Users see fewer permission prompts in Claude Code for the listed commands.
- Trust: Claude Code applies `permissions.allow` from a project only after the workspace has been trusted once interactively; hooks run regardless. Codex loads project hooks only for trusted projects.
- The hook needs `jq`, `uv`, and `git` on PATH; all are present in the dev container and required by the existing workflow.
- CI, Docker, and packaging are unchanged.

## Validation Results

Direct script tests in a generated Python 3.14 project (stdin JSON crafted from the documented shapes):

```bash
# Claude Code shape: formatted, unfixable F401 reported, exit 2
echo '{"cwd":"$PWD","tool_input":{"file_path":"src/test_copier/a.py"}}' | bash .agents/hooks/format-python.sh
# Codex apply_patch shape with two files and a deleted README: both formatted, exit 2
jq -n --arg cmd "$(printf '*** Begin Patch\n*** Update File: src/test_copier/b.py\n...\n*** Add File: src/test_copier/c.py\n...\n*** Delete File: README.md\n*** End Patch')" \
  '{tool_name:"apply_patch", tool_input:{command:$cmd}}' | bash .agents/hooks/format-python.sh
# Clean file: exit 0. Non-Python file: exit 0 without running ruff.
```

End-to-end with Claude Code in the same project:

```bash
claude -p --allowedTools "Write,Edit,Read" 'Create src/test_copier/from_claude.py with <badly formatted content> ... fix any hook diagnostics'
# Claude's report: Write triggered the hook, which reformatted the file; the remaining F401 was
# fixed with a second Edit, after which the hook reported no errors.
uv run --frozen ruff check src/test_copier/from_claude.py          # All checks passed!
uv run --frozen ruff format --check src/test_copier/from_claude.py  # 1 file already formatted
```

Codex end-to-end could not be completed: `codex exec` loaded the session hooks but the account hit its usage limit before the edit. The Codex path is covered by the `apply_patch`-shaped direct test above and by the documented `tool_input.command` field.
