### PR TITLE
docs: document the agent hooks and their trust requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,10 @@ your-project/
 - `.codex/hooks.json`: the same `PostToolUse` hook for Codex
 - `.agents/hooks/format-python.sh`: the hook script, runs `ruff format` and `ruff check --fix` on the edited file
 
+Both tools apply this configuration only in a trusted project. Claude Code asks once when you open the
+project; Codex additionally requires reviewing and trusting the hook with `/hooks`, and silently skips it
+until then.
+
 ## Q&A
 
 ### How do I run type checking?

--- a/template/README.md
+++ b/template/README.md
@@ -30,6 +30,22 @@ uv run ruff check .
 uv run ruff check . --fix
 ```
 
+### AI Coding Agents
+
+Rules for agents live in `AGENTS.md` (`CLAUDE.md` imports it). A shared hook formats and lints every Python
+file right after Claude Code or Codex edits it, and reports the remaining diagnostics back to the agent:
+
+- `.agents/hooks/format-python.sh`: the hook script, runs `ruff format` and `ruff check --fix`
+- `.claude/settings.json`: Claude Code permissions and the `PostToolUse` hook (committed; put personal
+  overrides in `.claude/settings.local.json`, which is git-ignored)
+- `.codex/hooks.json`: the same `PostToolUse` hook for Codex
+
+Both tools require the project to be trusted before they apply its configuration:
+
+- Claude Code: accept the trust prompt the first time you open the project.
+- Codex: trust the project, then review and trust the hook with `/hooks`. Until you do, Codex skips the
+  hook without reporting an error.
+
 ### Docker Development
 
 The template includes a complete Docker setup:


### PR DESCRIPTION
## Overview and Background

The generated project's README now describes the agent configuration shipped in #37 and states what a user must do before it takes effect. Verifying the Codex path end to end showed that Codex loads project hooks only when the `.codex/` layer is trusted **and** the hook definition itself has been reviewed and trusted through `/hooks`; until then it skips the hook without printing an error. A first Codex run in a fresh generated project therefore left an unformatted file behind with no indication why. The generated README also did not mention the hook or the settings files at all.

## Related Issues

None. Documents the configuration added in #37.

## Implementation Approach

Documentation only. The generated README gains an "AI Coding Agents" section listing the three files and the trust requirement for each tool; the repository README gets the same trust note appended to its existing file list. No behavior changes, because the trust step is a deliberate safety mechanism in both tools and cannot be waived from the project side.

## Changes

- `template/README.md`: new "AI Coding Agents" section (files, `.claude/settings.local.json` for personal overrides, trust requirements for Claude Code and Codex).
- `README.md`: trust note added to the existing AI Editor Support list.

## Impact

- User-facing: generated projects explain how to activate the hook. No code, dependency, or CI change.
- Existing projects receive the README change through the normal `copier update` three-way merge.

## Validation Results

Behavior that motivated the change, observed in a project generated from `main`:

```bash
# Untrusted project: Codex creates the file, hook never runs
codex exec -s workspace-write -c 'features.hooks=true' '<write a badly formatted .py>'
# hook: Stop only; file left unformatted; ruff check reports I001 and F401

# Trusted project and trusted hook: the hook runs and feeds diagnostics back
codex exec -s workspace-write -c 'features.hooks=true' \
  -c 'projects."<abs path>".trust_level="trusted"' --dangerously-bypass-hook-trust '<same prompt>'
# hook: PostToolUse -> apply_patch result replaced with "Script error: F401 `os` imported but unused"
# Codex then patched the file again; final state:
uv run --frozen ruff check src/test_copier/from_codex.py          # All checks passed!
uv run --frozen ruff format --check src/test_copier/from_codex.py  # 1 file already formatted
```

Rendered the README from this branch with `copier copy` and confirmed the new section appears with no unrendered Jinja.
