### PR TITLE
fix: answer new prompts when updating child repositories

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -133,7 +133,9 @@ jobs:
           git -C /tmp/test-copier-lifecycle commit -m "chore: initialize generated project"
       - name: Update to current template
         run: |
-          uvx copier update --vcs-ref HEAD --defaults /tmp/test-copier-lifecycle
+          # Same flags as .github/workflows/trigger-template-update.yml, so the
+          # tested update path matches the one used to reach child repositories.
+          uvx copier update --vcs-ref HEAD -A --defaults --trust /tmp/test-copier-lifecycle
           if git -C /tmp/test-copier-lifecycle diff --quiet; then
             echo "Copier update produced no changes"
             exit 1

--- a/.github/workflows/trigger-template-update.yml
+++ b/.github/workflows/trigger-template-update.yml
@@ -30,8 +30,10 @@ jobs:
       - name: Update template in child repository
         working-directory: child-repo
         run: |
-          # Update from template
-          uvx copier update -A --trust
+          # Update from template. --defaults answers prompts added since the
+          # child repository was last updated; without it Copier would try to
+          # ask interactively and fail.
+          uvx copier update -A --defaults --trust
 
       - name: Check for changes
         id: changes


### PR DESCRIPTION
## Overview and Background

Pushing the `v2.0.0` tag ran the template distribution workflow, and its `Update template in child repository` step failed:

```
🎤 Which license do you want to use? Choose None to keep the project unlicensed.
Interactive session required: Use `--defaults` and/or `--data`/`--data-file`
```

`copier update -A` skips questions that already have a recorded answer, but the `license` prompt added in #34 is absent from `.copier-answers.yml` in any repository generated before it. With no answer to reuse and no terminal, Copier aborts. The Release workflow itself succeeded, so `v2.0.0` exists; only the propagation to child repositories failed.

The repository's own `Template lifecycle` job did not catch this because it called `copier update` with `--defaults`, which answers new prompts, while the distribution workflow did not.

## Related Issues

None. Regression from the `license` prompt added in #34.

## Implementation Approach

- Add `--defaults` to the distribution workflow's `copier update`. Prompts added since the child repository was last updated take their default value; every previously answered question still keeps the child's own answer because `-A` remains in place. This is the resolution Copier's own error message points to, and it keeps working for any prompt added in the future.
- Give the `Template lifecycle` CI job the same flag set (`-A --defaults --trust`) so the path exercised in CI matches the one that actually reaches child repositories.

The workflow opens a pull request rather than pushing, so a person still reviews whatever the defaults produced before it lands in a child repository.

## Changes

- `.github/workflows/trigger-template-update.yml`: `copier update -A --defaults --trust`, with a comment explaining why `--defaults` is required.
- `.github/workflows/test.yml`: lifecycle job uses the same flags, with a comment tying the two commands together.

## Impact

- Child repositories updating from `v2.0.0` onward receive `license: MIT` (the prompt's default) unless they answer otherwise. Their `pyproject.toml` gains `license = "MIT"` and `license-files = ["LICENSE"]`. A `LICENSE` file is created only when the repository does not already have one, because `LICENSE` is listed in `_skip_if_exists`. A repository that wants a different license can edit `.copier-answers.yml` before merging the generated pull request, or edit the pull request itself.
- No change to generated project contents, the template, or the Release workflow.

## Validation Results

Reproduced the failure and verified the fix against a child repository generated from the `v1.0.0` tag and committed as a git repository, mirroring what the workflow does.

```bash
# Before: the exact command the workflow ran
uvx copier update -A --trust < /dev/null
# Updating to template version 2.0.0
# Warning: Input is not a terminal (fd=0).
# Interactive session required: Use `--defaults` and/or `--data`/`--data-file`

# After: the command from this PR
uvx copier update -A --defaults --trust < /dev/null
# Updating to template version 2.0.0        (completes, exit 0)
grep -E '_commit|license|python_version' .copier-answers.yml
# _commit: v2.0.0
# license: MIT
# python_version: '3.13'      <- pre-existing answer preserved, not reset to the new 3.14 default
git status --short | wc -l    # 26 changed or added files
```

Also ran the `Template lifecycle` job's steps locally with the new flags: generate from `v1.0.0`, commit, update to `HEAD`, assert a diff and a changed `_commit`, then `uv build`.

```
diff produced and revision updated: ok
Successfully built dist/lifecycle_project-0.0.1-py3-none-any.whl
build artifacts: ok
```
