### PR TITLE
fix: open the child repository PR when Copier leaves conflicts

### DIFF
--- a/.github/workflows/trigger-template-update.yml
+++ b/.github/workflows/trigger-template-update.yml
@@ -28,6 +28,7 @@ jobs:
         uses: astral-sh/setup-uv@v10.0.1
 
       - name: Update template in child repository
+        id: update
         working-directory: child-repo
         run: |
           # Update from template. --defaults answers prompts added since the
@@ -35,11 +36,36 @@ jobs:
           # ask interactively and fail.
           uvx copier update -A --defaults --trust
 
+          # Copier writes conflicting files with inline markers and leaves them
+          # unmerged in the index, which stops the pull request action from
+          # creating its branch. Stage them so the pull request is still opened,
+          # and describe them so the markers are resolved before it is merged.
+          conflicts="$(git diff --name-only --diff-filter=U)"
+          if [ -n "${conflicts}" ]; then
+            echo "conflicts=true" >> "$GITHUB_OUTPUT"
+            {
+              echo "conflict_note<<CONFLICT_NOTE_EOF"
+              echo "### Conflicts to resolve"
+              echo
+              echo "Copier could not merge these files. They are committed with conflict markers"
+              echo '(`<<<<<<<`, `=======`, `>>>>>>>`); resolve every marker before merging.'
+              echo
+              echo "${conflicts}" | sed 's/^/- `/; s/$/`/'
+              echo "CONFLICT_NOTE_EOF"
+            } >> "$GITHUB_OUTPUT"
+            echo "${conflicts}" | sed 's/^/::warning::Conflict left for manual resolution in /'
+            git add -A
+          else
+            echo "conflicts=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Check for changes
         id: changes
         working-directory: child-repo
         run: |
-          if git diff --quiet; then
+          # git diff alone would miss an update that only adds files, because
+          # those stay untracked until the pull request action commits them.
+          if [ -z "$(git status --porcelain)" ]; then
             echo "has_changes=false" >> $GITHUB_OUTPUT
           else
             echo "has_changes=true" >> $GITHUB_OUTPUT
@@ -53,7 +79,7 @@ jobs:
           path: child-repo
           commit-message: |
             Update template to version ${{ github.event.release.tag_name || 'latest' }}
-          title: "Update template to version ${{ github.event.release.tag_name || 'latest' }}"
+          title: "Update template to version ${{ github.event.release.tag_name || 'latest' }}${{ steps.update.outputs.conflicts == 'true' && ' (resolve conflicts)' || '' }}"
           body: |
             ## Template Update
 
@@ -63,6 +89,8 @@ jobs:
             - Updated from template: ${{ github.repository }}
             - Template version: ${{ github.event.release.tag_name || 'latest' }}
             ${{ github.event.release.html_url && format('- Release notes: {0}', github.event.release.html_url) || '' }}
+
+            ${{ steps.update.outputs.conflict_note }}
 
             ### Testing
             Please review the changes and test the updated template before merging.


### PR DESCRIPTION
## Overview and Background

The `v2.0.1` tag got past the interactive-prompt failure fixed in #40, and then failed one step later:

```
[command] git checkout --progress -B 393b6e0a-... HEAD --
error: you need to resolve your current index first
README.md: needs merge
```

`copier update` succeeded, but `README.md` in the child repository could not be merged automatically. Copier writes such files with inline conflict markers and leaves them unmerged in the index, then exits 0. `peter-evans/create-pull-request` starts by creating its branch with `git checkout -B`, which refuses to run while the index has unmerged entries, so no pull request was opened and the whole update was lost.

While reproducing this I also found that the change-detection step used `git diff --quiet`, which does not see untracked files. An update that only adds files (this release adds `.agents/`, `.claude/` and `.codex/`) would have been reported as "no changes" and skipped.

## Related Issues

None. Follow-up to #40, same workflow.

## Implementation Approach

- Keep Copier's default inline conflict markers rather than switching to `--conflict rej`. I tested both against the real child repository: with `rej` the index stays clean, but the merged file silently loses the rejected hunk and a `README.md.rej` file is committed alongside it. Inline markers keep both versions visible in the diff and cannot be merged by accident without someone noticing.
- After the update, collect unmerged paths with `git diff --name-only --diff-filter=U` and `git add -A` so the branch can be created. The conflict markers travel into the pull request, where a person resolves them.
- Make that impossible to miss: the paths go into the job log as `::warning::` annotations, the pull request title gains a `(resolve conflicts)` suffix, and the body gains a section naming each conflicting file. The body text is built as a multi-line step output, because GitHub expression string literals cannot contain newlines.
- Detect changes with `git status --porcelain` instead of `git diff --quiet`.

## Changes

- `.github/workflows/trigger-template-update.yml`: stage and report conflicts in the update step; conditional title suffix and conflict section in the pull request; change detection via `git status`.

## Impact

- A conflicting update now reaches the child repository as a pull request that says what needs resolving, instead of failing the workflow and delivering nothing.
- An update consisting only of new files is no longer skipped.
- No change to the template, the generated project, or the Release workflow.

## Validation Results

Extracted both `run` scripts from the workflow with a YAML parser and ran them against a real clone of `mjun0812/python-project-template` updated to `v2.0.1`, which reproduces the conflict.

Conflict case:

```
::warning::Conflict left for manual resolution in README.md
conflicts=true
conflict_note<<CONFLICT_NOTE_EOF
### Conflicts to resolve

Copier could not merge these files. They are committed with conflict markers
(`<<<<<<<`, `=======`, `>>>>>>>`); resolve every marker before merging.

- `README.md`
CONFLICT_NOTE_EOF

unmerged left: []
git checkout -B pr-test HEAD --    # checkout OK  (the command that failed in CI)
has_changes=true
```

No-conflict and no-change cases, after committing the update:

```
conflicts=false
has_changes=false
```

Add-only case, with a single untracked file present:

```
new check:  has_changes=true
old check:  has_changes=false   # the behavior being fixed
```
